### PR TITLE
Windows support

### DIFF
--- a/libraries/TH/THDiskFile.h
+++ b/libraries/TH/THDiskFile.h
@@ -3,15 +3,15 @@
 
 #include "THFile.h"
 
-THFile *THDiskFile_new(const char *name, const char *mode, int isQuiet);
-THFile *THPipeFile_new(const char *name, const char *mode, int isQuiet);
+TH_API THFile *THDiskFile_new(const char *name, const char *mode, int isQuiet);
+TH_API THFile *THPipeFile_new(const char *name, const char *mode, int isQuiet);
 
-const char *THDiskFile_name(THFile *self);
+TH_API const char *THDiskFile_name(THFile *self);
 
-int THDiskFile_isLittleEndianCPU(void);
-int THDiskFile_isBigEndianCPU(void);
-void THDiskFile_nativeEndianEncoding(THFile *self);
-void THDiskFile_littleEndianEncoding(THFile *self);
-void THDiskFile_bigEndianEncoding(THFile *self);
+TH_API int THDiskFile_isLittleEndianCPU(void);
+TH_API int THDiskFile_isBigEndianCPU(void);
+TH_API void THDiskFile_nativeEndianEncoding(THFile *self);
+TH_API void THDiskFile_littleEndianEncoding(THFile *self);
+TH_API void THDiskFile_bigEndianEncoding(THFile *self);
 
 #endif

--- a/libraries/TH/THFile.h
+++ b/libraries/TH/THFile.h
@@ -5,80 +5,80 @@
 
 typedef struct THFile__ THFile;
 
-int THFile_isOpened(THFile *self);
-int THFile_isQuiet(THFile *self);
-int THFile_isReadable(THFile *self);
-int THFile_isWritable(THFile *self);
-int THFile_isBinary(THFile *self);
-int THFile_isAutoSpacing(THFile *self);
-int THFile_hasError(THFile *self);
+TH_API int THFile_isOpened(THFile *self);
+TH_API int THFile_isQuiet(THFile *self);
+TH_API int THFile_isReadable(THFile *self);
+TH_API int THFile_isWritable(THFile *self);
+TH_API int THFile_isBinary(THFile *self);
+TH_API int THFile_isAutoSpacing(THFile *self);
+TH_API int THFile_hasError(THFile *self);
 
-void THFile_binary(THFile *self);
-void THFile_ascii(THFile *self);
-void THFile_autoSpacing(THFile *self);
-void THFile_noAutoSpacing(THFile *self);
-void THFile_quiet(THFile *self);
-void THFile_pedantic(THFile *self);
-void THFile_clearError(THFile *self);
+TH_API void THFile_binary(THFile *self);
+TH_API void THFile_ascii(THFile *self);
+TH_API void THFile_autoSpacing(THFile *self);
+TH_API void THFile_noAutoSpacing(THFile *self);
+TH_API void THFile_quiet(THFile *self);
+TH_API void THFile_pedantic(THFile *self);
+TH_API void THFile_clearError(THFile *self);
 
 /* scalar */
-unsigned char THFile_readByteScalar(THFile *self);
-char THFile_readCharScalar(THFile *self);
-short THFile_readShortScalar(THFile *self);
-int THFile_readIntScalar(THFile *self);
-long THFile_readLongScalar(THFile *self);
-float THFile_readFloatScalar(THFile *self);
-double THFile_readDoubleScalar(THFile *self);
+TH_API unsigned char THFile_readByteScalar(THFile *self);
+TH_API char THFile_readCharScalar(THFile *self);
+TH_API short THFile_readShortScalar(THFile *self);
+TH_API int THFile_readIntScalar(THFile *self);
+TH_API long THFile_readLongScalar(THFile *self);
+TH_API float THFile_readFloatScalar(THFile *self);
+TH_API double THFile_readDoubleScalar(THFile *self);
 
-void THFile_writeByteScalar(THFile *self, unsigned char scalar);
-void THFile_writeCharScalar(THFile *self, char scalar);
-void THFile_writeShortScalar(THFile *self, short scalar);
-void THFile_writeIntScalar(THFile *self, int scalar);
-void THFile_writeLongScalar(THFile *self, long scalar);
-void THFile_writeFloatScalar(THFile *self, float scalar);
-void THFile_writeDoubleScalar(THFile *self, double scalar);
+TH_API void THFile_writeByteScalar(THFile *self, unsigned char scalar);
+TH_API void THFile_writeCharScalar(THFile *self, char scalar);
+TH_API void THFile_writeShortScalar(THFile *self, short scalar);
+TH_API void THFile_writeIntScalar(THFile *self, int scalar);
+TH_API void THFile_writeLongScalar(THFile *self, long scalar);
+TH_API void THFile_writeFloatScalar(THFile *self, float scalar);
+TH_API void THFile_writeDoubleScalar(THFile *self, double scalar);
 
 /* storage */
-long THFile_readByte(THFile *self, THByteStorage *storage);
-long THFile_readChar(THFile *self, THCharStorage *storage);
-long THFile_readShort(THFile *self, THShortStorage *storage);
-long THFile_readInt(THFile *self, THIntStorage *storage);
-long THFile_readLong(THFile *self, THLongStorage *storage);
-long THFile_readFloat(THFile *self, THFloatStorage *storage);
-long THFile_readDouble(THFile *self, THDoubleStorage *storage);
+TH_API long THFile_readByte(THFile *self, THByteStorage *storage);
+TH_API long THFile_readChar(THFile *self, THCharStorage *storage);
+TH_API long THFile_readShort(THFile *self, THShortStorage *storage);
+TH_API long THFile_readInt(THFile *self, THIntStorage *storage);
+TH_API long THFile_readLong(THFile *self, THLongStorage *storage);
+TH_API long THFile_readFloat(THFile *self, THFloatStorage *storage);
+TH_API long THFile_readDouble(THFile *self, THDoubleStorage *storage);
 
-long THFile_writeByte(THFile *self, THByteStorage *storage);
-long THFile_writeChar(THFile *self, THCharStorage *storage);
-long THFile_writeShort(THFile *self, THShortStorage *storage);
-long THFile_writeInt(THFile *self, THIntStorage *storage);
-long THFile_writeLong(THFile *self, THLongStorage *storage);
-long THFile_writeFloat(THFile *self, THFloatStorage *storage);
-long THFile_writeDouble(THFile *self, THDoubleStorage *storage);
+TH_API long THFile_writeByte(THFile *self, THByteStorage *storage);
+TH_API long THFile_writeChar(THFile *self, THCharStorage *storage);
+TH_API long THFile_writeShort(THFile *self, THShortStorage *storage);
+TH_API long THFile_writeInt(THFile *self, THIntStorage *storage);
+TH_API long THFile_writeLong(THFile *self, THLongStorage *storage);
+TH_API long THFile_writeFloat(THFile *self, THFloatStorage *storage);
+TH_API long THFile_writeDouble(THFile *self, THDoubleStorage *storage);
 
 /* raw */
-long THFile_readByteRaw(THFile *self, unsigned char *data, long n);
-long THFile_readCharRaw(THFile *self, char *data, long n);
-long THFile_readShortRaw(THFile *self, short *data, long n);
-long THFile_readIntRaw(THFile *self, int *data, long n);
-long THFile_readLongRaw(THFile *self, long *data, long n);
-long THFile_readFloatRaw(THFile *self, float *data, long n);
-long THFile_readDoubleRaw(THFile *self, double *data, long n);
-long THFile_readStringRaw(THFile *self, const char *format, char **str_); /* you must deallocate str_ */
+TH_API long THFile_readByteRaw(THFile *self, unsigned char *data, long n);
+TH_API long THFile_readCharRaw(THFile *self, char *data, long n);
+TH_API long THFile_readShortRaw(THFile *self, short *data, long n);
+TH_API long THFile_readIntRaw(THFile *self, int *data, long n);
+TH_API long THFile_readLongRaw(THFile *self, long *data, long n);
+TH_API long THFile_readFloatRaw(THFile *self, float *data, long n);
+TH_API long THFile_readDoubleRaw(THFile *self, double *data, long n);
+TH_API long THFile_readStringRaw(THFile *self, const char *format, char **str_); /* you must deallocate str_ */
 
-long THFile_writeByteRaw(THFile *self, unsigned char *data, long n);
-long THFile_writeCharRaw(THFile *self, char *data, long n);
-long THFile_writeShortRaw(THFile *self, short *data, long n);
-long THFile_writeIntRaw(THFile *self, int *data, long n);
-long THFile_writeLongRaw(THFile *self, long *data, long n);
-long THFile_writeFloatRaw(THFile *self, float *data, long n);
-long THFile_writeDoubleRaw(THFile *self, double *data, long n);
-long THFile_writeStringRaw(THFile *self, const char *str, long size);
+TH_API long THFile_writeByteRaw(THFile *self, unsigned char *data, long n);
+TH_API long THFile_writeCharRaw(THFile *self, char *data, long n);
+TH_API long THFile_writeShortRaw(THFile *self, short *data, long n);
+TH_API long THFile_writeIntRaw(THFile *self, int *data, long n);
+TH_API long THFile_writeLongRaw(THFile *self, long *data, long n);
+TH_API long THFile_writeFloatRaw(THFile *self, float *data, long n);
+TH_API long THFile_writeDoubleRaw(THFile *self, double *data, long n);
+TH_API long THFile_writeStringRaw(THFile *self, const char *str, long size);
 
-void THFile_synchronize(THFile *self);
-void THFile_seek(THFile *self, long position);
-void THFile_seekEnd(THFile *self);
-long THFile_position(THFile *self);
-void THFile_close(THFile *self);
-void THFile_free(THFile *self);
+TH_API void THFile_synchronize(THFile *self);
+TH_API void THFile_seek(THFile *self, long position);
+TH_API void THFile_seekEnd(THFile *self);
+TH_API long THFile_position(THFile *self);
+TH_API void THFile_close(THFile *self);
+TH_API void THFile_free(THFile *self);
 
 #endif

--- a/libraries/TH/THGeneral.c
+++ b/libraries/TH/THGeneral.c
@@ -100,7 +100,7 @@ void THFree(void *ptr)
   free(ptr);
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 double log1p(const double x)
 {
   volatile double y;

--- a/libraries/TH/THGeneral.h
+++ b/libraries/TH/THGeneral.h
@@ -28,6 +28,12 @@
 
 #define THInf DBL_MAX
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#define popen _popen
+#define pclose _pclose
+#endif
+
 #if !defined(inline)
 # define inline
 #endif

--- a/libraries/TH/THGeneral.h
+++ b/libraries/TH/THGeneral.h
@@ -16,7 +16,7 @@
 # define TH_EXTERNC extern
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 # ifdef TH_EXPORTS
 #  define TH_API TH_EXTERNC __declspec(dllexport)
 # else
@@ -36,7 +36,7 @@
 # define M_PI 3.14159265358979323846
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 TH_API double log1p(const double x);
 #endif
 

--- a/libraries/TH/THMemoryFile.h
+++ b/libraries/TH/THMemoryFile.h
@@ -4,9 +4,9 @@
 #include "THFile.h"
 #include "THStorage.h"
 
-THFile *THMemoryFile_newWithStorage(THCharStorage *storage, const char *mode);
-THFile *THMemoryFile_new(const char *mode);
+TH_API THFile *THMemoryFile_newWithStorage(THCharStorage *storage, const char *mode);
+TH_API THFile *THMemoryFile_new(const char *mode);
 
-THCharStorage *THMemoryFile_storage(THFile *self);
+TH_API THCharStorage *THMemoryFile_storage(THFile *self);
 
 #endif

--- a/libraries/TH/generic/THBlas.h
+++ b/libraries/TH/generic/THBlas.h
@@ -3,17 +3,17 @@
 #else
 
 /* Level 1 */
-void THBlas_(swap)(long n, real *x, long incx, real *y, long incy);
-void THBlas_(scal)(long n, real a, real *x, long incx);
-void THBlas_(copy)(long n, real *x, long incx, real *y, long incy);
-void THBlas_(axpy)(long n, real a, real *x, long incx, real *y, long incy);
-real THBlas_(dot)(long n, real *x, long incx, real *y, long incy);
+TH_API void THBlas_(swap)(long n, real *x, long incx, real *y, long incy);
+TH_API void THBlas_(scal)(long n, real a, real *x, long incx);
+TH_API void THBlas_(copy)(long n, real *x, long incx, real *y, long incy);
+TH_API void THBlas_(axpy)(long n, real a, real *x, long incx, real *y, long incy);
+TH_API real THBlas_(dot)(long n, real *x, long incx, real *y, long incy);
 
 /* Level 2 */
-void THBlas_(gemv)(char trans, long m, long n, real alpha, real *a, long lda, real *x, long incx, real beta, real *y, long incy);
-void THBlas_(ger)(long m, long n, real alpha, real *x, long incx, real *y, long incy, real *a, long lda);
+TH_API void THBlas_(gemv)(char trans, long m, long n, real alpha, real *a, long lda, real *x, long incx, real beta, real *y, long incy);
+TH_API void THBlas_(ger)(long m, long n, real alpha, real *x, long incx, real *y, long incy, real *a, long lda);
 
 /* Level 3 */
-void THBlas_(gemm)(char transa, char transb, long m, long n, long k, real alpha, real *a, long lda, real *b, long ldb, real beta, real *c, long ldc);
+TH_API void THBlas_(gemm)(char transa, char transb, long m, long n, long k, real alpha, real *a, long lda, real *b, long ldb, real beta, real *c, long ldc);
 
 #endif

--- a/libraries/luaT/luaT.h
+++ b/libraries/luaT/luaT.h
@@ -13,7 +13,7 @@
 #endif
 
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 # define DLL_EXPORT __declspec(dllexport)
 # define DLL_IMPORT __declspec(dllimport)
 # ifdef luaT_EXPORTS

--- a/openmp/lib/THOmp/THOmpLabConv.h
+++ b/openmp/lib/THOmp/THOmpLabConv.h
@@ -1,5 +1,15 @@
 #include "TH.h"
 
+#ifdef _WIN32
+# ifdef THOmp_EXPORTS
+#  define THOMP_API __declspec(dllexport)
+# else
+#  define THOMP_API __declspec(dllimport)
+# endif
+#else
+# define THOMP_API /**/
+#endif
+
 #define THOmpLab_(NAME)   TH_CONCAT_4(THOmp,Real,Lab_,NAME)
 
 #include "generic/THOmpLabConv.h"

--- a/openmp/lib/THOmp/generic/THOmpLabConv.h
+++ b/openmp/lib/THOmp/generic/THOmpLabConv.h
@@ -8,9 +8,9 @@ void THOmpLab_(fullConv2Dptr)(real *r_, real *t_, long ir, long ic, real *k_, lo
 void THOmpLab_(validConv2DRevptr)(real *r_, real *t_, long ir, long ic, real *k_, long kr, long kc, long sr, long sc);
 */
 
-void THOmpLab_(conv2DRevger)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol);
-void THOmpLab_(conv2Dger)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol, const char* type);
-void THOmpLab_(conv2Dmv)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol, const char *type);
+THOMP_API void THOmpLab_(conv2DRevger)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol);
+THOMP_API void THOmpLab_(conv2Dger)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol, const char* type);
+THOMP_API void THOmpLab_(conv2Dmv)(THTensor *r_, real beta, THTensor *t_, THTensor *k_, long srow, long scol, const char *type);
 
 #endif
 

--- a/packages/lab/generic/lab.h
+++ b/packages/lab/generic/lab.h
@@ -1,5 +1,5 @@
 #ifndef TH_GENERIC_FILE
-#define TH_GENERIC_FILE "generic/lab.c"
+#define TH_GENERIC_FILE "generic/lab.h"
 #else
 
 static int lab_(numel)(lua_State *L)

--- a/packages/lab/init.c
+++ b/packages/lab/init.c
@@ -1,15 +1,7 @@
 #include "luaT.h"
-
-extern void lab_Byteinit(lua_State *L);
-extern void lab_Charinit(lua_State *L);
-extern void lab_Shortinit(lua_State *L);
-extern void lab_Intinit(lua_State *L);
-extern void lab_Longinit(lua_State *L);
-extern void lab_Floatinit(lua_State *L);
-extern void lab_Doubleinit(lua_State *L);
+#include "lab.h"
 
 extern void lab_utils_init(lua_State *L);
-
 
 DLL_EXPORT int luaopen_liblab(lua_State *L)
 {

--- a/packages/lab/lab.c
+++ b/packages/lab/lab.c
@@ -21,7 +21,7 @@ static const void* torch_LongStorage_id;
 
 static const void* lab_default_tensor_id;
 
-#include "generic/lab.c"
+#include "generic/lab.h"
 #include "THGenerateAllTypes.h"
 
 static int lab_setdefaulttensortype(lua_State *L)

--- a/packages/lab/lab.c
+++ b/packages/lab/lab.c
@@ -2,7 +2,11 @@
 #include "luaT.h"
 #include "utils.h"
 
-#include "sys/time.h"
+#ifdef _WIN32
+#include <time.h>
+#else
+#include <sys/time.h>
+#endif
 
 #define torch_(NAME) TH_CONCAT_3(torch_, Real, NAME)
 #define torch_string_(NAME) TH_CONCAT_STRING_3(torch., Real, NAME)
@@ -46,19 +50,29 @@ static int lab_getdefaulttensortype(lua_State *L)
 
 static int lab_tic(lua_State* L)
 {
+  double ttime;
+#ifdef _WIN32
+  ttime = (double)clock() / CLOCKS_PER_SEC;
+#else
   struct timeval tv;
   gettimeofday(&tv,NULL);
-  double ttime = (double)tv.tv_sec + (double)(tv.tv_usec)/1000000.0;
+  ttime = (double)tv.tv_sec + (double)(tv.tv_usec)/1000000.0;
+#endif
   lua_pushnumber(L,ttime);
   return 1;
 }
 
 static int lab_toc(lua_State* L)
 {
+  lua_Number tictime = luaL_checknumber(L,1);
+  double toctime;
+#ifdef _WIN32
+  toctime = (double)clock() / CLOCKS_PER_SEC;
+#else
   struct timeval tv;
   gettimeofday(&tv,NULL);
-  double toctime = (double)tv.tv_sec + (double)(tv.tv_usec)/1000000.0;
-  lua_Number tictime = luaL_checknumber(L,1);
+  toctime = (double)tv.tv_sec + (double)(tv.tv_usec)/1000000.0;
+#endif
   lua_pushnumber(L,toctime-tictime);
   return 1;
 }

--- a/packages/lab/lab.h
+++ b/packages/lab/lab.h
@@ -1,0 +1,16 @@
+#ifndef LAB_INC
+#define LAB_INC
+
+#include "luaT.h"
+
+void lab_Byteinit(lua_State *L);
+void lab_Charinit(lua_State *L);
+void lab_Shortinit(lua_State *L);
+void lab_Intinit(lua_State *L);
+void lab_Longinit(lua_State *L);
+void lab_Floatinit(lua_State *L);
+void lab_Doubleinit(lua_State *L);
+void lab_init(lua_State *L);
+
+#endif
+

--- a/packages/torch/Timer.c
+++ b/packages/torch/Timer.c
@@ -1,13 +1,13 @@
 #include "general.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <time.h>
 #else
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 static time_t base_time = 0;
 #endif    
 
@@ -51,7 +51,7 @@ static double torch_Timer_systime()
 static int torch_Timer_new(lua_State *L)
 {
   Timer *timer = luaT_alloc(L, sizeof(Timer));
-#ifdef _MSC_VER
+#ifdef _WIN32
   while(!base_time)
     time(&base_time);
 #endif

--- a/packages/torch/general.h
+++ b/packages/torch/general.h
@@ -7,7 +7,7 @@
 #include "luaT.h"
 #include "TH.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 #define snprintf _snprintf
 #define popen _popen


### PR DESCRIPTION
This branch allows Torch 7 to be built on Windows with icc, and adds timer support. To compile:
- Install intel's compiler (msvc doesn't support c99)
- Launch cmake-gui
- Set CMAKE_C_FLAGS and CMAKE_CXX_FLAGS to "/Qopenmp /Qstd=c99"
- Set INTEL_COMPILER_DIR
- Generate
- Open Torch.sln
- Right-click the solution in the solution explorer, click Intel C++ Compiler Pro, click Use Intel C++
- Build the solution
- Build the INSTALL target

Some remaining warnings:

warning #63: shift count is too large, libraries\TH\generic/THTensorRandom.c:20 
warning #264: floating-point value does not fit in required floating-point type, packages\nn\generic/TemporalLogSoftMax.c:19    
