### PR TITLE
Make tensor accessors const correct

### DIFF
--- a/cuda/lib/THC/THCStorage.c
+++ b/cuda/lib/THC/THCStorage.c
@@ -7,7 +7,7 @@ void THCudaStorage_set(THCudaStorage *self, long index, float value)
   THCudaCheck(cudaMemcpy(self->data + index, &value, sizeof(float), cudaMemcpyHostToDevice));
 }
 
-float THCudaStorage_get(THCudaStorage *self, long index)
+float THCudaStorage_get(const THCudaStorage *self, long index)
 {
   float value;
   THArgCheck((index >= 0) && (index < self->size), 2, "index out of bounds");

--- a/libraries/TH/generic/THStorage.c
+++ b/libraries/TH/generic/THStorage.c
@@ -250,7 +250,7 @@ void THStorage_(set)(THStorage *self, long idx, real value)
   self->data[idx] = value;
 }
 
-real THStorage_(get)(THStorage *self, long idx)
+real THStorage_(get)(const THStorage *self, long idx)
 {
   THArgCheck((idx >= 0) && (idx < self->size), 2, "out of bounds");
   return self->data[idx];

--- a/libraries/TH/generic/THStorage.h
+++ b/libraries/TH/generic/THStorage.h
@@ -30,8 +30,8 @@ typedef struct THStorage
 
 } THStorage;
 
-TH_API real* THStorage_(data)(THStorage*);
-TH_API long THStorage_(size)(THStorage*);
+TH_API real* THStorage_(data)(const THStorage*);
+TH_API long THStorage_(size)(const THStorage*);
 
 /* slow access -- checks everything */
 TH_API void THStorage_(set)(THStorage*, long, real);

--- a/libraries/TH/generic/THStorage.h
+++ b/libraries/TH/generic/THStorage.h
@@ -35,7 +35,7 @@ TH_API long THStorage_(size)(THStorage*);
 
 /* slow access -- checks everything */
 TH_API void THStorage_(set)(THStorage*, long, real);
-TH_API real THStorage_(get)(THStorage*, long);
+TH_API real THStorage_(get)(const THStorage*, long);
 
 TH_API THStorage* THStorage_(new)(void);
 TH_API THStorage* THStorage_(newWithSize)(long size);

--- a/libraries/TH/generic/THTensor.c
+++ b/libraries/TH/generic/THTensor.c
@@ -620,7 +620,7 @@ void THTensor_(set1d)(THTensor *tensor, long x0, real value)
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0], value);
 }
 
-real THTensor_(get1d)(THTensor *tensor, long x0)
+real THTensor_(get1d)(const THTensor *tensor, long x0)
 {
   THArgCheck(tensor->nDimension == 1, 1, "tensor must have one dimension");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]), 2, "out of range");
@@ -634,7 +634,7 @@ void THTensor_(set2d)(THTensor *tensor, long x0, long x1, real value)
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1], value);
 }
 
-real THTensor_(get2d)(THTensor *tensor, long x0, long x1)
+real THTensor_(get2d)(const THTensor *tensor, long x0, long x1)
 {
   THArgCheck(tensor->nDimension == 2, 1, "tensor must have two dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]), 2, "out of range");
@@ -648,7 +648,7 @@ void THTensor_(set3d)(THTensor *tensor, long x0, long x1, long x2, real value)
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2], value);
 }
 
-real THTensor_(get3d)(THTensor *tensor, long x0, long x1, long x2)
+real THTensor_(get3d)(const THTensor *tensor, long x0, long x1, long x2)
 {
   THArgCheck(tensor->nDimension == 3, 1, "tensor must have three dimensions");
   THArgCheck( (x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]), 2, "out of range");
@@ -662,7 +662,7 @@ void THTensor_(set4d)(THTensor *tensor, long x0, long x1, long x2, long x3, real
   THStorage_(set)(tensor->storage, tensor->storageOffset+x0*tensor->stride[0]+x1*tensor->stride[1]+x2*tensor->stride[2]+x3*tensor->stride[3], value);
 }
 
-real THTensor_(get4d)(THTensor *tensor, long x0, long x1, long x2, long x3)
+real THTensor_(get4d)(const THTensor *tensor, long x0, long x1, long x2, long x3)
 {
   THArgCheck(tensor->nDimension == 4, 1, "tensor must have four dimensions");
   THArgCheck((x0 >= 0) && (x0 < tensor->size[0]) && (x1 >= 0) && (x1 < tensor->size[1]) && (x2 >= 0) && (x2 < tensor->size[2]) && (x3 >= 0) && (x3 < tensor->size[3]), 2, "out of range");

--- a/libraries/TH/generic/THTensor.c
+++ b/libraries/TH/generic/THTensor.c
@@ -3,28 +3,28 @@
 #else
 
 /**** access methods ****/
-THStorage *THTensor_(storage)(THTensor *self)
+THStorage *THTensor_(storage)(const THTensor *self)
 {
   return self->storage;
 }
 
-long THTensor_(storageOffset)(THTensor *self)
+long THTensor_(storageOffset)(const THTensor *self)
 {
   return self->storageOffset;
 }
 
-int THTensor_(nDimension)(THTensor *self)
+int THTensor_(nDimension)(const THTensor *self)
 {
   return self->nDimension;
 }
 
-long THTensor_(size)(THTensor *self, int dim)
+long THTensor_(size)(const THTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "out of range");
   return self->size[dim];
 }
 
-long THTensor_(stride)(THTensor *self, int dim)
+long THTensor_(stride)(const THTensor *self, int dim)
 {
   THArgCheck((dim >= 0) && (dim < self->nDimension), 2, "out of range");
   return self->stride[dim];
@@ -44,7 +44,7 @@ THLongStorage *THTensor_(newStrideOf)(THTensor *self)
   return stride;
 }
 
-real *THTensor_(data)(THTensor *self)
+real *THTensor_(data)(const THTensor *self)
 {
   if(self->storage)
     return (self->storage->data+self->storageOffset);
@@ -458,7 +458,7 @@ void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension, long size, 
   self->nDimension++;
 }
 
-int THTensor_(isContiguous)(THTensor *self)
+int THTensor_(isContiguous)(const THTensor *self)
 {
   long z = 1;
   int d;
@@ -475,7 +475,7 @@ int THTensor_(isContiguous)(THTensor *self)
   return 1;
 }
 
-long THTensor_(nElement)(THTensor *self)
+long THTensor_(nElement)(const THTensor *self)
 {
   if(self->nDimension == 0)
     return 0;

--- a/libraries/TH/generic/THTensor.h
+++ b/libraries/TH/generic/THTensor.h
@@ -112,9 +112,9 @@ TH_API void THTensor_(set2d)(THTensor *tensor, long x0, long x1, real value);
 TH_API void THTensor_(set3d)(THTensor *tensor, long x0, long x1, long x2, real value);
 TH_API void THTensor_(set4d)(THTensor *tensor, long x0, long x1, long x2, long x3, real value);
 
-TH_API real THTensor_(get1d)(THTensor *tensor, long x0);
-TH_API real THTensor_(get2d)(THTensor *tensor, long x0, long x1);
-TH_API real THTensor_(get3d)(THTensor *tensor, long x0, long x1, long x2);
-TH_API real THTensor_(get4d)(THTensor *tensor, long x0, long x1, long x2, long x3);
+TH_API real THTensor_(get1d)(const THTensor *tensor, long x0);
+TH_API real THTensor_(get2d)(const THTensor *tensor, long x0, long x1);
+TH_API real THTensor_(get3d)(const THTensor *tensor, long x0, long x1, long x2);
+TH_API real THTensor_(get4d)(const THTensor *tensor, long x0, long x1, long x2, long x3);
 
 #endif

--- a/libraries/TH/generic/THTensor.h
+++ b/libraries/TH/generic/THTensor.h
@@ -22,14 +22,14 @@ typedef struct THTensor
 
 
 /**** access methods ****/
-TH_API THStorage* THTensor_(storage)(THTensor *self);
-TH_API long THTensor_(storageOffset)(THTensor *self);
-TH_API int THTensor_(nDimension)(THTensor *self);
-TH_API long THTensor_(size)(THTensor *self, int dim);
-TH_API long THTensor_(stride)(THTensor *self, int dim);
+TH_API THStorage* THTensor_(storage)(const THTensor *self);
+TH_API long THTensor_(storageOffset)(const THTensor *self);
+TH_API int THTensor_(nDimension)(const THTensor *self);
+TH_API long THTensor_(size)(const THTensor *self, int dim);
+TH_API long THTensor_(stride)(const THTensor *self, int dim);
 TH_API THLongStorage *THTensor_(newSizeOf)(THTensor *self);
 TH_API THLongStorage *THTensor_(newStrideOf)(THTensor *self);
-TH_API real *THTensor_(data)(THTensor *self);
+TH_API real *THTensor_(data)(const THTensor *self);
 
 TH_API void THTensor_(setFlag)(THTensor *self, const char flag);
 TH_API void THTensor_(clearFlag)(THTensor *self, const char flag);
@@ -99,8 +99,8 @@ TH_API void THTensor_(select)(THTensor *self, THTensor *src, int dimension_, lon
 TH_API void THTensor_(transpose)(THTensor *self, THTensor *src, int dimension1_, int dimension2_);
 TH_API void THTensor_(unfold)(THTensor *self, THTensor *src, int dimension_, long size_, long step_);
     
-TH_API int THTensor_(isContiguous)(THTensor *self);
-TH_API long THTensor_(nElement)(THTensor *self);
+TH_API int THTensor_(isContiguous)(const THTensor *self);
+TH_API long THTensor_(nElement)(const THTensor *self);
 
 TH_API void THTensor_(retain)(THTensor *self);
 TH_API void THTensor_(free)(THTensor *self);


### PR DESCRIPTION
Make tensor/storage access methods take a const THTensor* as input instead of a THTensor*. This allows code that deals with const THTensor* to use THTensor_(get2d) etc. without compilation errors.
