### PR TITLE
I needed a way to do a derivative check on a Sequential...

### DIFF
--- a/extra/nn/test/test.lua
+++ b/extra/nn/test/test.lua
@@ -1013,6 +1013,24 @@ function nntest.VolumetricConvolution()
    mytester:asserteq(0, berr, torch.typename(module) .. ' - i/o backward err ')
 end
 
+function nntest.DerivativeCheck()
+	local epsilon = 0.0001
+	local encodingSize = 5
+	local input = torch.rand(2*encodingSize)
+	local output = input
+	
+	-- create autoencoder
+	local seq = nn.Sequential()
+	local loss = nn.MSECriterion()
+	seq:add(nn.Linear(2*encodingSize, encodingSize))
+	seq:add(nn.Tanh())
+	seq:add(nn.Linear(encodingSize, 2*encodingSize))
+	seq:add(nn.Tanh())	
+		
+	local check = seq:derivativeCheck(input, input, loss, epsilon)	
+	mytester:assertgt(epsilon, torch.mean(check), 'error with derivative check')
+end
+
 
 mytester:add(nntest)
 --mytester:add(test_SpatialConvolution)


### PR DESCRIPTION
In order to write the derivativeCheck I needed to provide a method to get all the parameters from a Sequential, so I added getParameters(). This essentially just calls getParameters() on the modules and concatenate them. Additionally, Sequential:fromParameters() was needed, which subsequently requires Modules:fromParameters().

Unfortunately, I couldn't see a good way to write a generic fromParameters() function, since a Module has no listing of its parameters. Thus, I wrote one just for Linear with the idea that it could be implemented for other modules. However, if Modules kept a list of their parameters, this could be moved into Module.

The function Sequential:derivativeCheck(input, output, criterion, epsilon) perturbs each parameter +/- epsilon to calculate the derivative and match against the computed gradient. I've added a method to the unit test that creates an auto encoder to test out the function.
