### PR TITLE
Removing references to deprecated lab package

### DIFF
--- a/extra/nn/dok/index.dok
+++ b/extra/nn/dok/index.dok
@@ -428,8 +428,7 @@ concatenated.
 mlp=nn.Concat(1);
 mlp:add(nn.Linear(5,3))
 mlp:add(nn.Linear(5,7))
-require "lab"
-print(mlp:forward(lab.randn(5)))
+print(mlp:forward(torch.randn(5)))
 </file>
 which gives the output:
 <file lua>
@@ -461,8 +460,7 @@ mlp:add( nn.Linear(10, 25) ) -- 10 input, 25 hidden units
 mlp:add( nn.Tanh() ) -- some hyperbolic tangent transfer function
 mlp:add( nn.Linear(25, 1) ) -- 1 output
 
-require "lab"
-print(mlp:forward(lab.randn(10)))
+print(mlp:forward(torch.randn(10)))
 </file>
 which gives the output:
 <file lua>
@@ -480,11 +478,10 @@ on dimension ''inputDimension''. It concatenates the results of its contained mo
 
 Example:
 <file lua>
- require "lab"
  mlp=nn.Parallel(2,1);     -- iterate over dimension 2 of input
  mlp:add(nn.Linear(10,3)); -- apply to first slice
  mlp:add(nn.Linear(10,2))  -- apply to first second slice
- print(mlp:forward(lab.randn(10,2)))
+ print(mlp:forward(torch.randn(10,2)))
 </file>
 gives the output:
 <file lua>
@@ -498,7 +495,6 @@ gives the output:
 
 A more complicated example:
 <file lua>
-require "lab"
 
 mlp=nn.Sequential();
 c=nn.Parallel(1,2)
@@ -510,12 +506,12 @@ for i=1,10 do
 end
 mlp:add(c)
 
-pred=mlp:forward(lab.randn(10,3))
+pred=mlp:forward(torch.randn(10,3))
 print(pred)
 
 for i=1,10000 do     -- Train for a few iterations
- x=lab.randn(10,3);
- y=lab.ones(2,10);
+ x=torch.randn(10,3);
+ y=torch.ones(2,10);
  pred=mlp:forward(x)
 
  criterion= nn.MSECriterion()
@@ -590,7 +586,7 @@ operates in exactly the same way as the [[#nn.Linear|Linear]] layer.
 A sparse input vector may be created as so..
 <file lua>
 
- x=lab.new({1, 0.1},{2, 0.3},{10, 0.3},{31, 0.2})
+ x=torch.Tensor({{1, 0.1},{2, 0.3},{10, 0.3},{31, 0.2}})
 
  print(x)
 
@@ -616,9 +612,9 @@ layer (10000 in the example).
 
 <file lua>
 m=nn.Abs()
-ii=lab.linspace(-5,5)
+ii=torch.linspace(-5,5)
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -652,7 +648,7 @@ function gradUpdate(mlp, x, y, criterion, learningRate)
 end
 
 for i=1,10000 do
- x=lab.rand(5)
+ x=torch.rand(5)
  y:copy(x); 
  for i=1,5 do y[i]=y[i]+i; end
  err=gradUpdate(mlp,x,y,nn.MSECriterion(),0.01)
@@ -698,7 +694,7 @@ end
 
 
 for i=1,10000 do
- x=lab.rand(5)
+ x=torch.rand(5)
  y:copy(x); y:mul(math.pi);
  err=gradUpdate(mlp,x,y,nn.MSECriterion(),0.01)
 end
@@ -739,7 +735,7 @@ function gradUpdate(mlp,x,y,criterion,learningRate)
 end
 
 for i=1,10000 do
- x=lab.rand(5)
+ x=torch.rand(5)
  y:copy(x); y:cmul(sc);
  err=gradUpdate(mlp,x,y,nn.MSECriterion(),0.01)
 end
@@ -847,7 +843,7 @@ allocation or memory copy in this module. It sets the
 dimension to zero.
 
 <file lua>
-torch> x=lab.linspace(1,5,5)
+torch> x=torch.linspace(1,5,5)
 torch> =x
  1
  2
@@ -958,8 +954,7 @@ Example:
 mlp=nn.Sequential();
 mlp:add(nn.Select(1,3))
 
-require "lab"
-x=lab.randn(10,5)
+x=torch.randn(10,5)
 print(x)
 print(mlp:forward(x))
 </file>
@@ -990,7 +985,6 @@ to emulate the behavior
 of [[#nn.Parallel|Parallel]], or to select various parts of an input Tensor to 
 perform operations on. Here is a fairly complicated example:
 <file lua>
-require "lab"
 
 mlp=nn.Sequential();
 c=nn.Concat(2) 
@@ -1003,12 +997,12 @@ for i=1,10 do
 end
 mlp:add(c)
 
-pred=mlp:forward(lab.randn(10,3))
+pred=mlp:forward(torch.randn(10,3))
 print(pred)
 
 for i=1,10000 do     -- Train for a few iterations
- x=lab.randn(10,3);
- y=lab.ones(2,10);
+ x=torch.randn(10,3);
+ y=torch.ones(2,10);
  pred=mlp:forward(x)
 
  criterion= nn.MSECriterion()
@@ -1027,10 +1021,10 @@ end
 Applies the ''exp'' function element-wise to the input Tensor,
 thus outputting a Tensor of the same dimension.
 <file lua>
-ii=lab.linspace(-2,2)
+ii=torch.linspace(-2,2)
 m=nn.Exp()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1044,10 +1038,10 @@ gnuplot.grid(true)
 Takes the square of each element.
 
 <file lua>
-ii=lab.linspace(-5,5)
+ii=torch.linspace(-5,5)
 m=nn.Square()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1060,10 +1054,10 @@ gnuplot.grid(true)
 Takes the square root of each element.
 
 <file lua>
-ii=lab.linspace(0,5)
+ii=torch.linspace(0,5)
 m=nn.Sqrt()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1078,10 +1072,10 @@ gnuplot.grid(true)
 Raises each element to its ''pth'' power.
 
 <file lua>
-ii=lab.linspace(0,2)
+ii=torch.linspace(0,2)
 m=nn.Power(1.25)
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1104,10 +1098,10 @@ thus outputting a Tensor of the same dimension.
   * ''f(x)'' = ''x,'' ''otherwise.''
 
 <file lua>
-ii=lab.linspace(-2,2)
+ii=torch.linspace(-2,2)
 m=nn.HardTanh()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1130,10 +1124,10 @@ Applies the hard shrinkage function element-wise to the input
   * ''f(x) = 0, otherwise''
 
 <file lua>
-ii=lab.linspace(-2,2)
+ii=torch.linspace(-2,2)
 m=nn.HardShrink(0.85)
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1155,10 +1149,10 @@ Applies the hard shrinkage function element-wise to the input
   * ''f(x) = 0, otherwise''
 
 <file lua>
-ii=lab.linspace(-2,2)
+ii=torch.linspace(-2,2)
 m=nn.SoftShrink(0.85)
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1178,7 +1172,7 @@ where ''shift'' = ''max_i x_i''.
 
 
 <file lua>
-ii=lab.exp(lab.abs(lab.randn(10)))
+ii=torch.exp(torch.abs(torch.randn(10)))
 m=nn.SoftMax()
 oo=m:forward(ii)
 gnuplot.plot({'Input',ii,'+-'},{'Output',oo,'+-'})
@@ -1198,7 +1192,7 @@ where ''shift'' = ''max_i x_i''.
 
 
 <file lua>
-ii=lab.exp(lab.abs(lab.randn(10)))
+ii=torch.exp(torch.abs(torch.randn(10)))
 m=nn.SoftMin()
 oo=m:forward(ii)
 gnuplot.plot({'Input',ii,'+-'},{'Output',oo,'+-'})
@@ -1215,10 +1209,10 @@ Can be used to constrain the output of a machine to always be positive.
 ''SoftPlus'' is defined as ''f_i(x)'' = ''log(1 + exp(x_i)))''.
 
 <file lua>
-ii=lab.randn(10)
+ii=torch.randn(10)
 m=nn.SoftPlus()
 oo=m:forward(ii)
-go=lab.ones(10)
+go=torch.ones(10)
 gi=m:backward(ii,go)
 gnuplot.plot({'Input',ii,'+-'},{'Output',oo,'+-'},{'gradInput',gi,'+-'})
 gnuplot.grid(true)
@@ -1233,10 +1227,10 @@ Applies the ''SoftSign'' function to an n-dimensioanl input Tensor.
 ''SoftSign'' is defined as ''f_i(x) = x_i / (1+|x_i|)''
 
 <file lua>
-ii=lab.linspace(-5,5)
+ii=torch.linspace(-5,5)
 m=nn.SoftSign()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1252,10 +1246,10 @@ Applies the ''LogSigmoid'' function to an n-dimensional input Tensor.
 
 
 <file lua>
-ii=lab.randn(10)
+ii=torch.randn(10)
 m=nn.LogSigmoid()
 oo=m:forward(ii)
-go=lab.ones(10)
+go=torch.ones(10)
 gi=m:backward(ii,go)
 gnuplot.plot({'Input',ii,'+-'},{'Output',oo,'+-'},{'gradInput',gi,'+-'})
 gnuplot.grid(true)
@@ -1272,10 +1266,10 @@ Applies the ''LogSoftmax'' function to an n-dimensional input Tensor.
 where  ''a'' = ''sum_j exp(x_j)''.
 
 <file lua>
-ii=lab.randn(10)
+ii=torch.randn(10)
 m=nn.LogSoftMax()
 oo=m:forward(ii)
-go=lab.ones(10)
+go=torch.ones(10)
 gi=m:backward(ii,go)
 gnuplot.plot({'Input',ii,'+-'},{'Output',oo,'+-'},{'gradInput',gi,'+-'})
 gnuplot.grid(true)
@@ -1291,10 +1285,10 @@ thus outputting a Tensor of the same dimension.
 ''Sigmoid'' is defined as ''f(x)'' = ''1/(1+exp(-x))''.
 
 <file lua>
-ii=lab.linspace(-5,5)
+ii=torch.linspace(-5,5)
 m=nn.Sigmoid()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1308,10 +1302,10 @@ Applies the ''Tanh'' function element-wise to the input Tensor,
 thus outputting a Tensor of the same dimension.
 
 <file lua>
-ii=lab.linspace(-3,3)
+ii=torch.linspace(-3,3)
 m=nn.Tanh()
 oo=m:forward(ii)
-go=lab.ones(100)
+go=torch.ones(100)
 gi=m:backward(ii,go)
 gnuplot.plot({'f(x)',ii,oo,'+-'},{'df/dx',ii,gi,'+-'})
 gnuplot.grid(true)
@@ -1509,7 +1503,7 @@ For this example we use an external package
 require 'image'
 require 'nn'
 lena = image.rgb2y(image.lena())
-ker = lab.ones(11)
+ker = torch.ones(11)
 m=nn.SpatialSubtractiveNormalization(1,ker)
 processed = m:forward(lena)
 w1=image.display(lena)
@@ -1565,8 +1559,7 @@ dw=1;   -- we step once and go on to the next sequence element
 
 mlp=nn.TemporalConvolution(inp,outp,kw,dw)
 
-require "lab"
-x=lab.rand(7,inp) -- a sequence of 7 elements
+x=torch.rand(7,inp) -- a sequence of 7 elements
 print(mlp:forward(x))
 </file>
 which gives:
@@ -1583,7 +1576,7 @@ which gives:
 
 This is equivalent to:
 <file lua>
-weights=lab.reshape(mlp.weight,inp) -- weights applied to all
+weights=torch.reshape(mlp.weight,inp) -- weights applied to all
 bias= mlp.bias[1];
 for i=1,x:size(1) do -- for each sequence element
   element= x[i]; -- features of ith sequence element
@@ -1712,8 +1705,7 @@ mlp= nn.ConcatTable()
 mlp:add(nn.Linear(5,2))
 mlp:add(nn.Linear(5,3))
 
-require "lab"
-pred=mlp:forward(lab.randn(5));
+pred=mlp:forward(torch.randn(5));
 for i,k in pairs(pred) do print(i,k); end
 </file>
 which gives the output:
@@ -1741,9 +1733,8 @@ mlp= nn.ParallelTable()
 mlp:add(nn.Linear(10,2))
 mlp:add(nn.Linear(5,3))
 
-require "lab"
-x=lab.randn(10)
-y=lab.rand(5)
+x=torch.randn(10)
+y=torch.rand(5)
 
 pred=mlp:forward{x,y}
 for i,k in pairs(pred) do print(i,k); end
@@ -1771,9 +1762,8 @@ Creates a module that takes a Tensor as input and outputs several tables, splitt
 
 Example 1:
 <file lua>
-require "lab"
 mlp=nn.SplitTable(2)
-x=lab.randn(4,3)
+x=torch.randn(4,3)
 pred=mlp:forward(x)
 for i,k in pairs(pred) do print(i,k); end
 </file>
@@ -1803,9 +1793,8 @@ gives the output:
 
 Example 2:
 <file lua>
-require "lab"
 mlp=nn.SplitTable(1)
-pred=mlp:forward(lab.randn(10,3))
+pred=mlp:forward(torch.randn(10,3))
 for i,k in pairs(pred) do print(i,k); end
 </file>
 gives the output:
@@ -1837,7 +1826,6 @@ gives the output:
 
 A more complicated example:
 <file lua>
-require "lab"
 
 mlp=nn.Sequential();       --Create a network that takes a Tensor as input
 mlp:add(nn.SplitTable(2))
@@ -1851,11 +1839,11 @@ mlp:add(c)                 --Outputing a table with 2 elements
 mlp:add(p) 
 mlp:add(nn.JoinTable(1))   --Finally, the tables are joined together and output. 
 
-pred=mlp:forward(lab.randn(10,2))
+pred=mlp:forward(torch.randn(10,2))
 print(pred)
 
 for i=1,100 do             -- A few steps of training such a network.. 
- x=lab.ones(10,2);
+ x=torch.ones(10,2);
  y=torch.Tensor(3); y:copy(x:select(2,1,1):narrow(1,1,3))
  pred=mlp:forward(x)
 
@@ -1879,10 +1867,9 @@ Creates a module that takes a list of Tensors as input and outputs a Tensor by j
 
 Example:
 <file lua>
-require "lab"
-x=lab.randn(5,1)
-y=lab.randn(5,1)
-z=lab.randn(2,1)
+x=torch.randn(5,1)
+y=torch.randn(5,1)
+z=torch.randn(2,1)
 
 print(nn.JoinTable(1):forward{x,y})
 print(nn.JoinTable(2):forward{x,y})
@@ -1919,7 +1906,6 @@ gives the output:
 
 A more complicated example:
 <file lua>
-require "lab"
 
 mlp=nn.Sequential();       --Create a network that takes a Tensor as input
  c=nn.ConcatTable()        --The same Tensor goes through two different Linear
@@ -1932,11 +1918,11 @@ mlp:add(c)                 --Outputing a table with 2 elements
 mlp:add(p) 
 mlp:add(nn.JoinTable(1))   --Finally, the tables are joined together and output. 
 
-pred=mlp:forward(lab.randn(10))
+pred=mlp:forward(torch.randn(10))
 print(pred)
 
 for i=1,100 do             -- A few steps of training such a network.. 
- x=lab.ones(10);
+ x=torch.ones(10);
  y=torch.Tensor(3); y:copy(x:narrow(1,1,3))
  pred=mlp:forward(x)
 
@@ -1962,9 +1948,8 @@ This is useful when combined with the module
 in case you do not wish to do anything to one of the input Tensors.
 Example:
 <file lua>
-require "lab"
 mlp=nn.Identity()
-print(mlp:forward(lab.ones(5,2)))
+print(mlp:forward(torch.ones(5,2)))
 </file>
 gives the output: 
 <file lua>
@@ -1993,7 +1978,7 @@ cr_wrap=nn.CriterionTable(cr)
 mlp:add(cr_wrap)         -- and then applies the criterion.
 
 for i=1,100 do 		 -- Do a few training iterations
-  x=lab.ones(5);          -- Make input features.
+  x=torch.ones(5);          -- Make input features.
   y=torch.Tensor(3); 
   y:copy(x:narrow(1,1,3)) -- Make output label.
   err=mlp:forward{x,y}    -- Forward both input and output.
@@ -2014,8 +1999,8 @@ Example:
 <file lua>
 mlp_l1=nn.PairwiseDistance(1)
 mlp_l2=nn.PairwiseDistance(2)
-x=lab.new(1,2,3) 
-y=lab.new(4,5,6)
+x=torch.Tensor(1,2,3) 
+y=torch.Tensor(4,5,6)
 print(mlp_l1:forward({x,y}))
 print(mlp_l2:forward({x,y}))
 </file>
@@ -2056,8 +2041,8 @@ mlp:add(nn.PairwiseDistance(1))
 crit=nn.HingeEmbeddingCriterion(1)
 
 -- lets make two example vectors
-x=lab.rand(5)
-y=lab.rand(5)
+x=torch.rand(5)
+y=torch.rand(5)
 
 
 -- Use a typical generic gradient update function
@@ -2096,8 +2081,8 @@ end
 Example:
 <file lua>
 mlp=nn.DotProduct()
-x=lab.new(1,2,3) 
-y=lab.new(4,5,6)
+x=torch.Tensor(1,2,3) 
+y=torch.Tensor(4,5,6)
 print(mlp:forward({x,y}))
 </file>
 gives the output:
@@ -2131,9 +2116,9 @@ prla:add(mlp1)
 prla:add(mlp2)
 mlp:add(prla)
 
-x=lab.rand(5); 
-y=lab.rand(5)
-z=lab.rand(5)
+x=torch.rand(5); 
+y=torch.rand(5)
+z=torch.rand(5)
 
 
 print(mlp1:forward{x,x})
@@ -2189,8 +2174,8 @@ end
 Example:
 <file lua>
 mlp=nn.CosineDistance()
-x=lab.new(1,2,3) 
-y=lab.new(4,5,6)
+x=torch.Tensor(1,2,3) 
+y=torch.Tensor(4,5,6)
 print(mlp:forward({x,y}))
 </file>
 gives the output:
@@ -2224,14 +2209,14 @@ mlp:add(nn.CosineDistance())
 
 
 -- lets make two example vectors
-x=lab.rand(5)
-y=lab.rand(5)
+x=torch.rand(5)
+y=torch.rand(5)
 
 -- Grad update function..
 function gradUpdate(mlp, x, y, learningRate)
 local pred = mlp:forward(x)
 if pred[1]*y < 1 then
- gradCriterion=lab.new(-y)
+ gradCriterion=torch.Tensor(-y)
  mlp:zeroGradParameters()
  mlp:backward(x, gradCriterion)
  mlp:updateParameters(learningRate)
@@ -2265,9 +2250,8 @@ Creates a module that wraps a Criterion module so that it can accept a Table of 
 Example:
 <file lua>
 mlp = nn.CriterionTable(nn.MSECriterion())
-require "lab"
-x=lab.randn(5)
-y=lab.randn(5)
+x=torch.randn(5)
+y=torch.randn(5)
 print(mlp:forward{x,x})
 print(mlp:forward{x,y})
 </file>
@@ -2279,7 +2263,6 @@ gives the output:
 
 Here is a more complex example of embedding the criterion into a network:
 <file lua>
-require "lab"
 
 function table.print(t)
  for i,k in pairs(t) do print(i,k); end
@@ -2296,7 +2279,7 @@ mlp:add(cmlp)
 mlp:add(nn.CriterionTable(nn.MSECriterion())) -- Apply the Criterion
 
 for i=1,20 do                                 -- Train for a few iterations
- x=lab.ones(5);
+ x=torch.ones(5);
  y=torch.Tensor(3); y:copy(x:narrow(1,1,3))
  err=mlp:forward{x,y}                         -- Pass in both input and output
  print(err)
@@ -2313,7 +2296,7 @@ end
 Takes a table of tensors and outputs summation of all tensors.
 
 <file lua>
-ii = {lab.ones(5),lab.ones(5)*2,lab.ones(5)*3}
+ii = {torch.ones(5),torch.ones(5)*2,torch.ones(5)*3}
 =ii[1]
  1
  1
@@ -2356,7 +2339,7 @@ subtraction between them.
 
 <file lua>
 m=nn.CSubTable()
-=m:forward({lab.ones(5)*2.2,lab.ones(5)})
+=m:forward({torch.ones(5)*2.2,torch.ones(5)})
  1.2000
  1.2000
  1.2000
@@ -2371,7 +2354,7 @@ m=nn.CSubTable()
 Takes a table of tensors and outputs the multiplication of all of them.
 
 <file lua>
-ii = {lab.ones(5)*2,lab.ones(5)*3,lab.ones(5)*4}
+ii = {torch.ones(5)*2,torch.ones(5)*3,torch.ones(5)*4}
 m=nn.CMulTable()
 =m:forward(ii)
  24
@@ -2391,7 +2374,7 @@ division between them.
 
 <file lua>
 m=nn.CDivTable()
-=m:forward({lab.ones(5)*2.2,lab.ones(5)*4.4})
+=m:forward({torch.ones(5)*2.2,torch.ones(5)*4.4})
  0.5000
  0.5000
  0.5000
@@ -2534,7 +2517,6 @@ sets a different value of ''m''.
 Example:
 <file lua>
 require "nn"
-require "lab"
 
 function gradUpdate(mlp, x, y, criterion, learningRate)
   local pred = mlp:forward(x)
@@ -2548,8 +2530,8 @@ end
 mlp=nn.Sequential()
 mlp:add(nn.Linear(5,1))
 
-x1=lab.rand(5)
-x2=lab.rand(5)
+x1=torch.rand(5)
+x2=torch.rand(5)
 criterion=nn.MarginCriterion(1)
 
 for i=1,1000 do
@@ -2668,8 +2650,8 @@ mlp:add(nn.PairwiseDistance(1))
 crit=nn.HingeEmbeddingCriterion(1)
 
 -- lets make two example vectors
-x=lab.rand(5)
-y=lab.rand(5)
+x=torch.rand(5)
+y=torch.rand(5)
 
 
 -- Use a typical generic gradient update function
@@ -2788,9 +2770,9 @@ mlpa:add(prla)
 
 crit=nn.MarginRankingCriterion(0.1)
 
-x=lab.randn(5)
-y=lab.randn(5)
-z=lab.randn(5)
+x=torch.randn(5)
+y=torch.randn(5)
+z=torch.randn(5)
 
 
 -- Use a typical generic gradient update function
@@ -2892,11 +2874,10 @@ We show an example here on a classical XOR problem.
 We first need to create a dataset, following the conventions described in
 [[#nn.StochasticGradientTrain|StochasticGradient]].
 <file lua>
-require "lab"
 dataset={};
 function dataset:size() return 100 end -- 100 examples
 for i=1,dataset:size() do 
-  local input = lab.randn(2);     -- normally distributed example in 2d
+  local input = torch.randn(2);     -- normally distributed example in 2d
   local output = torch.Tensor(1);
   if input[1]*input[2]>0 then     -- calculate label for XOR function
     output[1] = -1;
@@ -2992,10 +2973,9 @@ criterion = nn.MSECriterion()
 We create data //on the fly// and feed it to the neural network.
 
 <file lua>
-require "lab"
 for i = 1,2500 do
   -- random sample
-  local input= lab.randn(2);     -- normally distributed example in 2d
+  local input= torch.randn(2);     -- normally distributed example in 2d
   local output= torch.Tensor(1);
   if input[1]*input[2] > 0 then  -- calculate label for XOR function
     output[1] = -1

--- a/pkg/dok/dokinstall/index.dok
+++ b/pkg/dok/dokinstall/index.dok
@@ -76,9 +76,9 @@ sudo apt-get install libblas-dev
 </file>
 
 LAPACK installation is required for anyone who wants to use linear
-algebra operations like [[..lab:index#lab.linbalg.dok|eigenvalue
-computation, singular value decomposition]]. Ubuntu distribution
-provides LAPACK through ''liblapack'' package.
+algebra operations like [[..:torch:maths#torch.eig|eigenvalue
+computation]], [[..:torch:maths#torch.svd|singular value decomposition]].
+Ubuntu distribution provides LAPACK through ''liblapack'' package.
 
 <file>
 sudo apt-get install liblapack-dev
@@ -200,7 +200,7 @@ Try the IDE: torch -ide
 Type help() for more info
 Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
 Lua 5.1  Copyright (C) 1994-2008 Lua.org, PUC-Rio
-torch> =lab.randn(10,10)
+torch> =torch.randn(10,10)
  1.3862  1.5983 -2.0216 -0.1502  1.9467 -1.2322  0.1628 -2.6253  1.3255 -0.5784
  0.1363 -1.2638 -1.0661  0.0233  1.3064 -0.8817  1.1424  1.0952 -0.2147  0.7712
  1.1348 -0.8596 -0.6102  0.9137 -1.1582 -0.3301  0.5250  1.3631 -0.4051 -0.9549


### PR DESCRIPTION
I removed references to the lab package in the documentation.  I think I got the dokuwiki syntax for links correct, but haven't actually tested.  Is there a way to view the edited dok files without completely reinstalling Torch?  Or a way to install just the documentation?

Also, the tests in ./extra/cuda/pkg/cunn/test/test.lua use lab.randn, but I didn't touch those.
