### PR TITLE
Quoting arguments in torch-exe

### DIFF
--- a/exe/torch-exe/torch-exe.lua
+++ b/exe/torch-exe/torch-exe.lua
@@ -71,7 +71,10 @@ if interactive then
 end
 
 -- re-pack arguments
-args = table.concat(arg, ' ')
+for i,arg_i in ipairs(arg) do
+   arg[i] = arg_i:gsub('"','\\"')
+end
+args = '"' .. table.concat(arg, '" "') .. '"'
 
 -- test qlua existence
 if lua == 'torch-qlua' and not paths.filep(paths.concat(paths.install_bin,lua)) then


### PR DESCRIPTION
In exe/torch-exe/torch-exe.lua, the command line arguments need to be re-quoted or there can be errors:

```
$ torch script.lua "quoted(arg)"
Type help() for more info
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `/usr/local/bin/torch-lua -e "require 'torch-env'"  -i quoted(arg)'
```
