### PR TITLE
Removed reading from an undeclared var

### DIFF
--- a/pkg/torch/File.lua
+++ b/pkg/torch/File.lua
@@ -193,7 +193,7 @@ function File:readObject()
          if object.read then
             object:read(self, versionNumber)
          elseif type(object) == 'table' then
-            local var = self:readObject(var)
+            local var = self:readObject()
             for k,v in pairs(var) do
                object[k] = v
             end


### PR DESCRIPTION
Hi,

I found a minor typo in File.lua.
An undeclared variable was read in the code.

I found it, because I let lua to raise an error, when reading a missing var.
http://www.lua.org/pil/14.2.html
