### PR TITLE
Printing of nil values

### DIFF
--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -112,12 +112,12 @@ function print(obj,...)
       _G.io.flush()
       return
    end
-   local m = getmaxlen(obj)
    if _G.type(obj) == 'table' then
       local mt = _G.getmetatable(obj)
       if mt and mt.__tostring__ then
          _G.io.write(mt.__tostring__(obj))
       else
+         local m = getmaxlen(obj)
          local tos = _G.tostring(obj)
          local obj_w_usage = false
          if tos and not _G.string.find(tos,'table: ') then

--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -107,7 +107,7 @@ end
 -- lua tables, and objects.
 local print_new
 function print(obj,...)
-   if obj == nil then
+   if obj == nil and select('#',...) == 0 then
       _G.io.write('\n')
       _G.io.flush()
       return


### PR DESCRIPTION
I found that torch print() is not printing anything after a nil argument.
Example:
    print(1, nil, 2)

output: 1
expected output: 1 nil 2

I fixed the detecting of the end of args in print().
I also improved the speed of print() a bit.
The changes are small.
