### PR TITLE
remove temp files when done in gnuplot

### DIFF
--- a/pkg/gnuplot/gnuplot.lua
+++ b/pkg/gnuplot/gnuplot.lua
@@ -52,6 +52,9 @@ local function getfigure(n)
 end
 
 local function gnuplothasterm(term)
+   -- if we ever end up requiring gnuplot >= 4.4 as a dependency, we could
+   -- instead do 'gnuplot -e "print GPVAL_TERMINALS"', which prints the terminals
+   -- on a single line without any pager annoyance
    if not _gptable.exe then
       return false--error('gnuplot exe is not found, can not chcek terminal')
    end
@@ -61,15 +64,20 @@ local function gnuplothasterm(term)
    fi:write('set terminal\n\n')
    fi:close()
    os.execute(getexec() .. ' < ' .. tfni .. ' > ' .. tfno .. ' 2>&1 ')
+   os.remove(tfni)
    local tf = io.open(tfno,'r')
+   local hasterm = false
    local s = tf:read('*l')
    while s do
-      if s:match('^.*%s+  '.. term .. ' ') then
-         return true
+      if s:match('^.*%s+ '.. term .. ' ') then
+         hasterm = true
+         break
       end
       s = tf:read('*l')
    end
-   return false
+   tf:close()
+   os.remove(tfno)
+   return hasterm
 end
 
 local function findgnuplotversion(exe)


### PR DESCRIPTION
This is just a quick fix to make the gnuplot wrapper remove the temporary files it creates. Our cluster's /tmp was getting a bit crowded:

find /tmp -iname 'lua_*'|wc -l
  1085923

You could also avoid calling gnuplothasterm multiple times by creating a table of supported terminals when the wrapper is loaded.

If you ever change your dependencies to gnuplot >= 4.4, then you could replace that awkward "set terminal\n\n" with a simple "gnuplot -e 'print GPVAL_TERMINALS'", which prints all supported terminals on a single line. This avoids issues with the pager's "Press enter to continue:" that currently get interleaved with the terminal list (quick fix for now: "PAGER=cat gnuplot").
