### PR TITLE
Fixed hessian parameter flattening

### DIFF
--- a/extra/nn/hessian.lua
+++ b/extra/nn/hessian.lua
@@ -336,7 +336,7 @@ function nn.hessian.enable()
       local flatParameters = flatten(parameters)
       local flatGradParameters = flatten(gradParameters)
       local flatHessianParameters
-      if hessianParameters[1] then
+      if hessianParameters and hessianParameters[1] then
          flatHessianParameters = flatten(hessianParameters)
       end
 


### PR DESCRIPTION
This previously failed for nn modules which do not return any hessian parameters.

The following program fails to run:

```
require 'nn'
require 'unsup'

net = nn.Parallel(1,1)
net:add(nn.Linear(1,1))
param, gradParam = net:getParameters()
```

I get an error about indexing of a non-existing variable:

```
/usr/local/stow/torch/bin/torch-lua: /usr/local/stow/torch/share/torch/lua/nn/hessian.lua:340: attempt to index local 'hessianParameters' (a nil value)
stack traceback:
    /usr/local/stow/torch/share/torch/lua/nn/hessian.lua:340: in function 'getParameters'
    ../../rchm/lstm_rnn.lua:135: in function '__init'
    /usr/local/stow/torch/share/torch/lua/torch/init.lua:43: in function </usr/local/stow/torch/share/torch/lua/torch/init.lua:39>
    [C]: in function 'LSTM_RNN'
    ./test_rchmRegression.lua:26: in function 'runModel'
    ./test_rchmRegression.lua:61: in function 'verify'
    ./test_rchmRegression.lua:94: in main chunk
    [C]: ?
```

It does not fail when using nn.Sequential and it also does not fail if unsup is not required. I'm not familiar with the hessian code but I suspect that nn.Sequential can return hessian parameters while nn.Parallel cannot, and furthermore that unsup enables the hessian extension.

I'm not sure whether the fix should be

```
if hessianParameters and hessianParameters[1] then
    ...
```

or just

```
if hessianParameters then
    ...
```
