### PR TITLE
Added missing form of CudaTensor:add

### DIFF
--- a/extra/cuda/lib/THC/THCTensorMath.cu
+++ b/extra/cuda/lib/THC/THCTensorMath.cu
@@ -87,6 +87,27 @@ void THCudaTensor_cadd(THCudaTensor *self_, float value, THCudaTensor *src)
   }
 }
 
+void THCudaTensor_cadd_tst(THCudaTensor *self_, THCudaTensor* src1, float value, THCudaTensor *src2)
+{
+  THArgCheck(THCudaTensor_nElement(self_) == THCudaTensor_nElement(src1), 3, "size do not match");
+  THArgCheck(THCudaTensor_nElement(self_) == THCudaTensor_nElement(src2), 3, "size do not match");
+
+  {
+    THCudaTensor *self = THCudaTensor_newContiguous(self_);
+
+    src1 = THCudaTensor_newContiguous(src1);
+    src2 = THCudaTensor_newContiguous(src2);
+
+    THCudaTensor_copy(self, src1);
+    cublasSaxpy(THCudaTensor_nElement(self), value, THCudaTensor_data(src2), 1, THCudaTensor_data(self), 1);
+    THCublasCheck();
+
+    THCudaTensor_free(src1);
+    THCudaTensor_free(src2);
+    THCudaTensor_freeCopyTo(self, self_);
+  }
+}
+
 void THCudaTensor_cmul(THCudaTensor *self_, THCudaTensor *src)
 {
   THArgCheck(THCudaTensor_nElement(self_) == THCudaTensor_nElement(src), 2, "size do not match");

--- a/extra/cuda/lib/THC/THCTensorMath.h
+++ b/extra/cuda/lib/THC/THCTensorMath.h
@@ -11,6 +11,7 @@ TH_API void THCudaTensor_mul(THCudaTensor *self, float value);
 TH_API void THCudaTensor_div(THCudaTensor *self, float value);
 
 TH_API void THCudaTensor_cadd(THCudaTensor *self, float value, THCudaTensor *src);  
+TH_API void THCudaTensor_cadd_tst(THCudaTensor *self, THCudaTensor *src1, float value, THCudaTensor *src2);
 TH_API void THCudaTensor_cmul(THCudaTensor *self, THCudaTensor *src);
 TH_API void THCudaTensor_cdiv(THCudaTensor *self, THCudaTensor *src);
 

--- a/extra/cuda/pkg/cutorch/TensorMath.lua
+++ b/extra/cuda/pkg/cutorch/TensorMath.lua
@@ -186,6 +186,11 @@ interface:wrap("add",
                cname("cadd"),
                {{name="CudaTensor", returned=true},
                 {name="float", default=1},
+                {name="CudaTensor"}},
+               cname("cadd_tst"),
+               {{name="CudaTensor", returned=true},
+                {name="CudaTensor"},
+                {name="float", default=1},
                 {name="CudaTensor"}})
 
 interface:wrap("mul",


### PR DESCRIPTION
This adds the form that performs x:add(y,s,z), which was previously missing.

For the C/CUDA code I had to add a second version of cadd. I named this cadd_tst to reflect the order of the operands (tensor, scalar, tensor).
