### PR TITLE
Allowed to print(nil)

### DIFF
--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -106,12 +106,13 @@ end
 -- this new print is much more verbose, automatically recursing through
 -- lua tables, and objects.
 local print_new
-function print(obj,...)
-   if obj == nil and select('#',...) == 0 then
+function print(...)
+   if select('#',...) == 0 then
       _G.io.write('\n')
       _G.io.flush()
       return
    end
+   local obj = ...
    if _G.type(obj) == 'table' then
       local mt = _G.getmetatable(obj)
       if mt and mt.__tostring__ then
@@ -150,9 +151,9 @@ function print(obj,...)
    else
       _G.io.write(_G.tostring(obj))
    end
-   if _G.select('#',...) > 0 then
+   if _G.select('#',...) > 1 then
       _G.io.write('    ')
-      print_new(...)
+      print_new(select(2,...))
    else
       _G.io.write('\n')
    end

--- a/extra/nn/SpatialConvolutionMap.lua
+++ b/extra/nn/SpatialConvolutionMap.lua
@@ -54,7 +54,7 @@ function nn.tables.random(nin, nout, nto)
    return tbl
 end
 
-function constructTableRev(conMatrix)
+local function constructTableRev(conMatrix)
    local conMatrixL = conMatrix:type('torch.LongTensor')
    -- Construct reverse lookup connection table
    local thickness = conMatrixL:select(2,2):max()

--- a/extra/nn/test/test.lua
+++ b/extra/nn/test/test.lua
@@ -795,7 +795,7 @@ function nntest.SpatialConvolutionMap()
    mytester:asserteq(0, berr, torch.typename(module) .. ' - i/o backward err ')
 end
 
-function batchcompare(smod, sin, plist)
+local function batchcompare(smod, sin, plist)
    local bs = torch.LongStorage(sin:size():size()+1)
    bs[1] = 1
    for i=1,sin:size():size() do bs[i+1] = sin:size()[i] end


### PR DESCRIPTION
I wanted the print(nil) and print(1, nil) to behave like in plain lua.
The following works with the commit:

```
t7> print(1, nil)
1    nil
t7> print(nil)
nil
```

BTW, I also marked constructTableRev() and batchcompare() as local.
I guess, it was not intended to export them.
