### PR TITLE
count and report assertions in Tester class

### DIFF
--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -9,6 +9,7 @@ end
 
 
 function Tester:assert_sub (condition, message)
+   self.countasserts = self.countasserts + 1
    if not condition then
       local ss = debug.traceback('tester',2)
       --print(ss)
@@ -70,7 +71,7 @@ function Tester:report(tests)
    if not tests then
       tests = self.tests
    end
-   print('Completed ' .. #tests .. ' tests with ' .. #self.errors .. ' errors')
+   print('Completed ' .. self.countasserts .. ' asserts in ' .. #tests .. ' tests with ' .. #self.errors .. ' errors')
    print()
    print(string.rep('-',80))
    for i,v in ipairs(self.errors) do
@@ -81,6 +82,7 @@ end
 
 function Tester:run(run_tests)
    local tests, testnames
+   self.countasserts = 0
    tests = self.tests
    testnames = self.testnames
    if type(run_tests) == 'string' then


### PR DESCRIPTION
This patches Tester.class to count and report the number of assertions evaluated during a call to Tester:run() -- it's offered in pretty much all test-suites, e.g. Junit even reports a '.' or 'F' for each assert. Example:

```
Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
Running 2 tests
__  ==> Done           

Completed 6 asserts in 2 tests with 0 errors

--------------------------------------------------------------------------------
```
