### PR TITLE
Extend Bernoulli distribution to p=0 and p=1

### DIFF
--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -233,6 +233,6 @@ int THRandom_geometric(double p)
 
 int THRandom_bernoulli(double p)
 {
-  THArgCheck(p > 0 && p < 1, 1, "must be > 0 and < 1");
+  THArgCheck(p >= 0 && p <= 1, 1, "must be >= 0 and <= 1");
   return(__uniform__() <= p);
 }

--- a/pkg/torch/dok/random.dok
+++ b/pkg/torch/dok/random.dok
@@ -101,5 +101,5 @@ Returns a random integer number according to a geometric distribution
 ====  [number] bernoulli([p]) ====
 {{anchor:torch.bernoulli}}
 
-Returns ''1'' with probability ''p'' and ''0'' with probability ''1-p''. ''p'' must satisfy ''0 < p < 1''.
+Returns ''1'' with probability ''p'' and ''0'' with probability ''1-p''. ''p'' must satisfy ''0 <= p <= 1''.
 By default ''p'' is equal to ''0.5''.


### PR DESCRIPTION
So far, torch.bernoulli(p) requires 0 < p < 1. While this is strictly speaking mathematically correct, allowing in practice p = 0 and p = 1 to sample from the limit constant case  is _very_ convenient  in many algorithms (eg. over-parametrization of a state space, where neurons can degenerate with a weight arbitrarily close to 0). 

This tolerance for p=0 and p=1 is implemented in Matlab's Stat Toolbox's binornd(), as well as in the very useful [Randraw package](http://www.mathworks.co.uk/matlabcentral/fileexchange/7309-randraw).

The attached patch implements this tolerance and documents it.
