### PR TITLE
Fix bug  in assertTableEq

### DIFF
--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -58,14 +58,24 @@ function Tester:assertTensorNe(ta, tb, condition, message)
    self:assert_sub(err>=condition,string.format('%s\n%s  val=%s, condition=%s',message,' TensorNE(~=) violation ', tostring(err), tostring(condition)))
 end
 
-function Tester:assertTableEq(ta, condition, message)
-   -- TODO: fix bug, the comparison below does not compare elements which are not in common
-   self:assert_sub(unpack(ta) == unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
+function areTablesEqual(ta, tb)
+   local function isIncludedIn(ta, tb)
+      for k, v in pairs(tb) do
+         if ta[k] ~= v then return false end
+      end
+      return true
+   end
+
+   -- TODO: compare recursively all sublists
+   return isIncludedIn(ta, tb) and isIncludedIn(tb, ta)
 end
 
-function Tester:assertTableNe(ta, condition, message)
-   -- TODO: fix bug, the comparison below does not compare elements which are not in common
-   self:assert_sub(unpack(ta) ~= unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
+function Tester:assertTableEq(ta, tb, message)
+  self:assert_sub(areTablesEqual(ta, tb), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
+end
+
+function Tester:assertTableNe(ta, tb, message)
+   self:assert_sub(not areTablesEqual(ta, tb), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
 end
 
 function Tester:assertError(f, message)

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -60,13 +60,15 @@ end
 
 function areTablesEqual(ta, tb)
    local function isIncludedIn(ta, tb)
+      if type(ta) ~= 'table' or type(tb) ~= 'table' then 
+         return ta == tb 
+      end
       for k, v in pairs(tb) do
-         if ta[k] ~= v then return false end
+         if not areTablesEqual(ta[k], v) then return false end
       end
       return true
    end
 
-   -- TODO: compare recursively all sublists
    return isIncludedIn(ta, tb) and isIncludedIn(tb, ta)
 end
 

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -58,12 +58,14 @@ function Tester:assertTensorNe(ta, tb, condition, message)
    self:assert_sub(err>=condition,string.format('%s\n%s  val=%s, condition=%s',message,' TensorNE(~=) violation ', tostring(err), tostring(condition)))
 end
 
-function Tester:assertTableNe(ta, condition, message)
-   self:assert_sub(unpack(ta) ~= unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
+function Tester:assertTableEq(ta, condition, message)
+   -- TODO: fix bug, the comparison below does not compare elements which are not in common
+   self:assert_sub(unpack(ta) == unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
 end
 
-function Tester:assertTableEq(ta, condition, message)
-   self:assert_sub(unpack(ta) == unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
+function Tester:assertTableNe(ta, condition, message)
+   -- TODO: fix bug, the comparison below does not compare elements which are not in common
+   self:assert_sub(unpack(ta) ~= unpack(condition), string.format('%s\n%s val=%s, condition=%s',message,' TableEQ(==) violation ', tostring(err), tostring(condition)))
 end
 
 function Tester:assertError(f, message)

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -360,8 +360,13 @@ function torchtest.logical()
    mytester:asserteq(x:nElement(),all:double():sum() , 'torch.logical')
 end
 
-function torchtest.TestAssertError()
-   mytester:assertError(function() error('hello') end, 'Error not caught')
+function torchtest.TestAsserts()
+   mytester:assertError(function() error('hello') end, 'assertError: Error not caught')
+
+   local x = torch.rand(100,100)*2-1;
+   local xx = x:clone();
+   mytester:assertTensorEq(x, xx, 1e-16, 'assertTensorEq: not deemed equal')
+   mytester:assertTensorNe(x, xx+1, 1e-16, 'assertTensorNe: not deemed different')
 end
 
 function torch.test()

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -375,6 +375,7 @@ function torchtest.BugInAssertTableEq()
    local tt = {1,2,3}
    mytester:assertTableEq(t, tt, 'assertTableEq: not deemed equal')
    mytester:assertTableNe(t, {3,2,1}, 'assertTableNe: not deemed different')
+   mytester:assertTableEq({1,2,{4,5}}, {1,2,{4,5}}, 'assertTableEq: fails on recursive lists')
    -- TODO: once a mechanism for testing that assert fails exist, test that the two asserts below do not pass
    -- should not pass: mytester:assertTableEq(t, {1,2}, 'assertTableNe: different size should not be equal') 
    -- should not pass: mytester:assertTableEq(t, {1,2,3,4}, 'assertTableNe: different size should not be equal')

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -367,19 +367,20 @@ function torchtest.TestAsserts()
    local xx = x:clone();
    mytester:assertTensorEq(x, xx, 1e-16, 'assertTensorEq: not deemed equal')
    mytester:assertTensorNe(x, xx+1, 1e-16, 'assertTensorNe: not deemed different')
-
 end
+
 
 function torchtest.BugInAssertTableEq()
    local t = {1,2,3}
    local tt = {1,2,3}
    mytester:assertTableEq(t, tt, 'assertTableEq: not deemed equal')
    mytester:assertTableNe(t, {3,2,1}, 'assertTableNe: not deemed different')
-   -- TODO: fix bug  below, where only the first components are compared
-   mytester:assertTableEq(t, {1,2}, 'assertTableNe: different size should not be equal') -- should err, doesn't
-   mytester:assertTableNe(t, {1,2}, 'assertTableNe: different size not deemed different') -- should pass, doesn't
-   mytester:assertTableEq(t, {1,2,3,4}, 'assertTableNe: different size should not be equal') -- should err, doesn't
-   mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different') -- should pass, doesn't
+   -- TODO: once a mechanism for testing that assert fails exist, test that the two asserts below do not pass
+   -- should not pass: mytester:assertTableEq(t, {1,2}, 'assertTableNe: different size should not be equal') 
+   -- should not pass: mytester:assertTableEq(t, {1,2,3,4}, 'assertTableNe: different size should not be equal')
+
+   mytester:assertTableNe(t, {1,2}, 'assertTableNe: different size not deemed different')
+   mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different')
 end
 
 function torch.test()

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -367,6 +367,19 @@ function torchtest.TestAsserts()
    local xx = x:clone();
    mytester:assertTensorEq(x, xx, 1e-16, 'assertTensorEq: not deemed equal')
    mytester:assertTensorNe(x, xx+1, 1e-16, 'assertTensorNe: not deemed different')
+
+end
+
+function torchtest.BugInAssertTableEq()
+   local t = {1,2,3}
+   local tt = {1,2,3}
+   mytester:assertTableEq(t, tt, 'assertTableEq: not deemed equal')
+   mytester:assertTableNe(t, {3,2,1}, 'assertTableNe: not deemed different')
+   -- TODO: fix bug  below, where only the first components are compared
+   mytester:assertTableEq(t, {1,2}, 'assertTableNe: different size should not be equal') -- should err, doesn't
+   mytester:assertTableNe(t, {1,2}, 'assertTableNe: different size not deemed different') -- should pass, doesn't
+   mytester:assertTableEq(t, {1,2,3,4}, 'assertTableNe: different size should not be equal') -- should err, doesn't
+   mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different') -- should pass, doesn't
 end
 
 function torch.test()


### PR DESCRIPTION
Hi guys

assertTableEq fails to distinguish between  table A and B if the A is shorter than B but matches on all its terms. The attached patch uses recursive comparison by double-inclusion to make sure the two tables actually match (recursively).

I also included tests to avoid regressions.
