### PR TITLE
Added an optional force option to writeObject.

### DIFF
--- a/pkg/torch/File.lua
+++ b/pkg/torch/File.lua
@@ -41,7 +41,7 @@ function File:isWritableObject(object)
    return typeidx
 end
 
-function File:writeObject(object)
+function File:writeObject(object, force)
    -- we use an environment to keep a record of written objects
    if not torch.getenv(self).writeObjects then
       torch.setenv(self, {writeObjects={}, writeObjectsRef={}, readObjects={}})
@@ -86,7 +86,7 @@ function File:writeObject(object)
       local objectsRef = torch.getenv(self).writeObjectsRef
       local index = objects[torch.pointer(object)]
 
-      if index then
+      if index and (not force) then
          -- if already exists, write only its index
          self:writeInt(index)
       else


### PR DESCRIPTION
I'm streaming a live recorded dataset to disk, where each sample is a table 
with a number of properties (e.g. GPS coords, compass heading, and a tensor with
the current frame of video), and the built-in writeObject caching requires a deep copy of 
every sample in order to work correctly, because I write each successive frame into the same tensor.

With this patch you can force writeObject to disregard caching and always write
the given object.

```
f:writeObject(sample, true)
```

If there were javadoc style comments, I would add to the comment string as well...
