### PR TITLE
Allow negative step with range

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -658,8 +658,8 @@ void THTensor_(range)(THTensor *r_, real xmin, real xmax, real step)
   long size;
   real i = 0;
 
-  THArgCheck(step > 0, 3, "step must be a positive number");
-  THArgCheck(xmax > xmin, 2, "upper bound must be larger than lower bound");
+  THArgCheck(step > 0 || step < 0, 3, "step must be a non-null number");
+  THArgCheck((step > 0) && (xmax > xmin) || (step < 0) && (xmax < xmin), 2, "upper bound and larger bound incoherent with step sign");
 
   size = (long)((xmax-xmin)/step+1);
   

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -99,6 +99,12 @@ function torchtest.range()
    torch.range(mxx,0,1)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.range value')
 end
+function torchtest.rangenegative()
+   local mx = torch.Tensor({1,0})
+   local mxx = torch.Tensor()
+   torch.range(mxx,1,0,-1)
+   mytester:asserteq(maxdiff(mx,mxx),0,'torch.range value for negative step')
+end
 function torchtest.randperm()
    local t=os.time()
    torch.manualSeed(t)


### PR DESCRIPTION
Allow to specify a negative step size in torch.range() -- much as in Matlab. Tests added and passed, too.

```
[julien@stmartin torch (NegativeStepRange=)]$ torch
Try the IDE: torch -ide
Type help() for more info
Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
Lua 5.1  Copyright (C) 1994-2008 Lua.org, PUC-Rio
t7> =torch.range(10,5,-1)
 10
  9
  8
  7
  6
  5
[torch.DoubleTensor of dimension 6]

t7> torch.test()
Running 33 tests
_________________________________  ==> Done              

Completed 77 asserts in 33 tests with 0 errors

--------------------------------------------------------------------------------
t7> 
```
