### PR TITLE
Reported the full traceback on a test failure.

### DIFF
--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -88,9 +88,8 @@ end
 function Tester:pcall(f)
    local nerr = #self.errors
    -- local res = f()
-   local stat, result = pcall(f)
+   local stat, result = xpcall(f, debug.traceback)
    if not stat then
-      result = result .. debug.traceback()
       self.errors[#self.errors+1] = self.curtestname .. '\n Function call failed \n' .. result .. '\n'
    end
    return stat, result, stat and (nerr == #self.errors)


### PR DESCRIPTION
I modified Tester:pcall() to provide the full traceback to the cause of the failure.
The xpcall() is used to get the traceback before unwinding the stack.
