### PR TITLE
Raise error("interrupted!") when torch-qlua is interrupted by ctrl-C.

### DIFF
--- a/exe/qtlua/qlua/qluaapplication.cpp
+++ b/exe/qtlua/qlua/qluaapplication.cpp
@@ -11,6 +11,9 @@
 #if HAVE_UNISTD_H
 # include <unistd.h>
 #endif
+#if HAVE_SIGNAL_H
+# include <signal.h>
+#endif
 
 #include <QApplication>
 #include <QDateTime>
@@ -42,7 +45,32 @@
 #include "qluaconsole.h"
 
 
+#ifdef HAVE_SIGNAL
+static void lstop(lua_State *L, lua_Debug *ar)
+{
+  (void)ar;  /* unused arg. */
+  lua_sethook(L, NULL, 0, 0);
+  /* Avoid luaL_error -- a C hook doesn't add an extra frame. */
+  luaL_where(L, 0);
+  lua_pushfstring(L, "%sinterrupted!", lua_tostring(L, -1));
+  lua_error(L);
+}
 
+static void laction(int i)
+{
+  signal(i, SIG_DFL); /* if another SIGINT happens before lstop,
+                         terminate process (default action) */
+  QtLuaEngine *engine = QLuaApplication::engine();
+  if (engine)
+    {
+      QtLuaLocker lua(engine, 250);
+      struct lua_State *L = lua;
+      if (L) {
+          lua_sethook(L, lstop, LUA_MASKCALL | LUA_MASKRET | LUA_MASKCOUNT, 1);
+      }
+    }
+}
+#endif // HAVE_SIGNAL
 
 
 // ------- private class
@@ -359,7 +387,6 @@ QLuaApplication::Private::printBadOption(const char *option)
 }
 
 
-
 int 
 QLuaApplication::Private::doCall(struct lua_State *L, int nargs)
 {
@@ -367,7 +394,13 @@ QLuaApplication::Private::doCall(struct lua_State *L, int nargs)
   int base = lua_gettop(L) - nargs;
   lua_pushcfunction(L, luaQ_traceback);
   lua_insert(L, base);
+#if HAVE_SIGNAL
+  signal(SIGINT, laction);
+#endif
   status = luaQ_pcall(L, nargs, 0, base, theEngine);
+#if HAVE_SIGNAL
+  signal(SIGINT, SIG_DFL);
+#endif
   lua_remove(L, base);
   if (status)
     lua_gc(L, LUA_GCCOLLECT, 0);


### PR DESCRIPTION
I modified torch-qlua to react to ctrl-C like torch-lua.

Example usage:

```
$ torch-qlua -e 'while true do os.clock() end'
^Ctorch-qlua: interrupted!
stack traceback:
    [C]: ?
    [C]: in function 'clock'
    [string "while true do os.clock() end"]:1: in main chunk
```
