### PR TITLE
Linear:updateGradInput avoids NaN and inf

### DIFF
--- a/extra/nn/Linear.lua
+++ b/extra/nn/Linear.lua
@@ -52,11 +52,14 @@ end
 function Linear:updateGradInput(input, gradOutput)
    if self.gradInput then
 
+      local nElement = self.gradInput:nElement()
+      self.gradInput:resizeAs(input)
+      if self.gradInput:nElement() ~= nElement then
+         self.gradInput:zero()
+      end
       if input:dim() == 1 then
-         self.gradInput:resizeAs(input)
          self.gradInput:addmv(0, 1, self.weight:t(), gradOutput)
       elseif input:dim() == 2 then
-         self.gradInput:resizeAs(input)
          self.gradInput:addmm(0, 1, gradOutput, self.weight)
       end
 


### PR DESCRIPTION
The resize in Linear:updateGradInput can introduce NaN and inf into the
gradients. The resize itself leaves garbage in the gradInput tensor.
For normal numbers the subsequent addmm/addmv will clear the garbage.
However, if gradInput contains either nan or inf after the resize, the
multiply will result in nan instead of the desired result.

The following program re-creates the failure

```
require 'nn'

local function test(x)
    local w = nn.Linear(4,4)
    w.gradInput:resize(4,4):zero():div(0) -- gradInput is now all NaN
    w.gradInput:resize()                  -- gradInput is now the original size, but will resize back to NaNs
    w:updateGradInput(x,x)
    assert(torch.ne(w.gradInput, w.gradInput):sum() == 0,
        'gradInput contains NaNs. Size' .. tostring(x:size()))
end

test(torch.ones(2,4)) -- minibatch
test(torch.ones(4))   -- stochastic
```
