### PR TITLE
Updated local cpath

### DIFF
--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -289,10 +289,10 @@ local localinstalldir = paths.concat(os.getenv('HOME'),'.torch','usr')
 if paths.dirp(localinstalldir) then
    package.path = paths.concat(localinstalldir,'share','torch','lua','?','init.lua') .. ';' .. package.path
    package.path = paths.concat(localinstalldir,'share','torch','lua','?.lua') .. ';' ..  package.path
-   package.cpath = paths.concat(localinstalldir,'lib','torch','?.so') .. ';' .. package.cpath
-   package.cpath = paths.concat(localinstalldir,'lib','torch','?.dylib') .. ';' .. package.cpath
    package.cpath = paths.concat(localinstalldir,'lib','torch','lua','?.so') .. ';' .. package.cpath
    package.cpath = paths.concat(localinstalldir,'lib','torch','lua','?.dylib') .. ';' .. package.cpath
+   package.cpath = paths.concat(localinstalldir,'lib','torch','?.so') .. ';' .. package.cpath
+   package.cpath = paths.concat(localinstalldir,'lib','torch','?.dylib') .. ';' .. package.cpath
 end
 local localinstalldir = paths.concat(os.getenv('HOME'),'.luarocks')
 if paths.dirp(localinstalldir) then

--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -291,6 +291,8 @@ if paths.dirp(localinstalldir) then
    package.path = paths.concat(localinstalldir,'share','torch','lua','?.lua') .. ';' ..  package.path
    package.cpath = paths.concat(localinstalldir,'lib','torch','?.so') .. ';' .. package.cpath
    package.cpath = paths.concat(localinstalldir,'lib','torch','?.dylib') .. ';' .. package.cpath
+   package.cpath = paths.concat(localinstalldir,'lib','torch','lua','?.so') .. ';' .. package.cpath
+   package.cpath = paths.concat(localinstalldir,'lib','torch','lua','?.dylib') .. ';' .. package.cpath
 end
 local localinstalldir = paths.concat(os.getenv('HOME'),'.luarocks')
 if paths.dirp(localinstalldir) then


### PR DESCRIPTION
torch-pkg installs library files to <local-instal-prefix>/lib/torch/lua
(changed in c622014a5d25668f2308277d68fc9b1de5b2d0d2 and
e500d7cea89b2454b1219c3a883a0cae2f6cc9fe). torch-env now adds this
location to the cpath, whereas before it only added
<local-install-prefix>/lib/torch which was the correct location prior to
c622014a5d25668f2308277d68fc9b1de5b2d0d2.
