### PR TITLE
Cuda reductions

### DIFF
--- a/extra/cuda/lib/THC/THCTensorMath.cu
+++ b/extra/cuda/lib/THC/THCTensorMath.cu
@@ -480,7 +480,7 @@ void THCudaTensor_sum(THCudaTensor *self, THCudaTensor *src, long dimension)
 
 void THCudaTensor_max(THCudaTensor *self, THCudaTensor *src, long dimension)
 {
-  const float minfloat32 = 1.175494351e-38f;
+  const float minfloat32 = -3.402823466e+38f;
   return THCudaTensor_reduceDim(self, src, dimension, thrust::maximum<float>(), minfloat32);
 }
 

--- a/extra/cuda/pkg/cutorch/TensorMath.lua
+++ b/extra/cuda/pkg/cutorch/TensorMath.lua
@@ -240,7 +240,7 @@ for _,name in ipairs({"min", "max", "sum"}) do
                   {{name="CudaTensor"},
                    {name="float", creturned=true}},
                   cname(name),
-                  {{name="CudaTensor", returned=true},
+                  {{name="CudaTensor", default=true, returned=true},
                    {name="CudaTensor"},
                    {name="index"}})
 end


### PR DESCRIPTION
Resolved issues in previous pull request pointed out by @clementfarabet  (min/max/sum can now be called without passing in the output tensor) as well as a bug pointed out by @koraykv
