### PR TITLE
Improved norm computations

### DIFF
--- a/extra/cuda/lib/THC/THCTensorMath.cu
+++ b/extra/cuda/lib/THC/THCTensorMath.cu
@@ -996,7 +996,7 @@ struct norm_functor
   }
 };
 
-float THCudaTensor_norm(THCudaTensor *self, float value)
+float THCudaTensor_normall(THCudaTensor *self, float value)
 {
   self = THCudaTensor_newContiguous(self);
   long size = THCudaTensor_nElement(self);
@@ -1007,6 +1007,13 @@ float THCudaTensor_norm(THCudaTensor *self, float value)
   THCudaTensor_free(self);
   return pow(result, (float)1.0/value);
 }
+
+
+void THCudaTensor_norm(THCudaTensor* self, THCudaTensor* src, float value, long dimension)
+{
+  THCudaTensor_transformReduceDim(self, src, dimension, norm_functor(value), (float)0, thrust::plus<float>());
+}
+
 
 struct dist_functor
 {

--- a/extra/cuda/lib/THC/THCTensorMath.cu
+++ b/extra/cuda/lib/THC/THCTensorMath.cu
@@ -306,9 +306,10 @@ struct dim4 {
  *
  * Reduction along the innermost dimension is handled in a separate kernel.
  */
-template<class Op>
-__global__ void THCudaTensor_kernel_reduceOuterDim(float *tgt, float *src_,
-        dim4 src_stride, dim4 tgt_stride, dim4 size, Op op, float init)
+template<class UnaryFunction, class BinaryFunction>
+__global__ void THCudaTensor_kernel_transformReduceOuterDim(float *tgt, float *src_,
+        dim4 src_stride, dim4 tgt_stride, dim4 size,
+        UnaryFunction unary_op, BinaryFunction binary_op, float init)
 {
   const size_t reduce = 3;
 
@@ -318,7 +319,7 @@ __global__ void THCudaTensor_kernel_reduceOuterDim(float *tgt, float *src_,
     float *src = src_ + z * src_stride[2] + y * src_stride[1] + col;
     float acc = init;
     for(unsigned i=0; i < size[reduce]; i++) {
-      acc = op(acc, *src);
+      acc = binary_op(acc, unary_op(*src));
       src += src_stride[reduce];
     }
     tgt[z * tgt_stride[2] + y * tgt_stride[1] + col] = float(acc);
@@ -327,8 +328,9 @@ __global__ void THCudaTensor_kernel_reduceOuterDim(float *tgt, float *src_,
 
 
 
-template<class Op>
-__host__ void THCudaTensor_reduceOuterDim(THCudaTensor *tgt, THCudaTensor *src, long rdim, Op op, float init)
+template<class UnaryFunction, class BinaryFunction>
+__host__ void THCudaTensor_transformReduceOuterDim(THCudaTensor *tgt, THCudaTensor *src,
+        long rdim, UnaryFunction unary_op, BinaryFunction binary_op, float init)
 {
   const size_t reduce = 3;
   dim4 src_stride(0);
@@ -349,8 +351,8 @@ __host__ void THCudaTensor_reduceOuterDim(THCudaTensor *tgt, THCudaTensor *src, 
   unsigned maxGridDim = 1024; // anything < 64k is fine. The choice has no impact on performance.
   dim3 grid(min(maxGridDim, nBlockPerColumn), min(maxGridDim, size[1]), min(maxGridDim, size[2]));
 
-  THCudaTensor_kernel_reduceOuterDim<<<grid, threads>>>(THCudaTensor_data(tgt),
-          THCudaTensor_data(src), src_stride, tgt_stride, size, op, init);
+  THCudaTensor_kernel_transformReduceOuterDim<<<grid, threads>>>(THCudaTensor_data(tgt),
+          THCudaTensor_data(src), src_stride, tgt_stride, size, unary_op, binary_op, init);
   cudaError errcode = cudaGetLastError();
   if(errcode != cudaSuccess) {
     THError(cudaGetErrorString(errcode));
@@ -369,9 +371,9 @@ __host__ void THCudaTensor_reduceOuterDim(THCudaTensor *tgt, THCudaTensor *src, 
  *
  * Reduction along other dimensions is handled in a separate kernel.
  */
-template<class Op>
-__global__ void THCudaTensor_kernel_reduceInnermostDim(float *tgt, float *src_,
-        dim4 src_stride, dim4 tgt_stride, dim4 size, Op op, float init)
+template<class UnaryFunction, class BinaryFunction>
+__global__ void THCudaTensor_kernel_transformReduceInnermostDim(float *tgt, float *src_,
+        dim4 src_stride, dim4 tgt_stride, dim4 size, UnaryFunction unary_op, BinaryFunction binary_op, float init)
 {
   __shared__ float sbuf[16][32]; // 8kB
 
@@ -389,20 +391,20 @@ __global__ void THCudaTensor_kernel_reduceInnermostDim(float *tgt, float *src_,
       sbuf[threadIdx.y][threadIdx.x] = init;
       unsigned col = bCol + threadIdx.x;
       if(row < size[1] && col < size[0]) {
-        sbuf[threadIdx.y][threadIdx.x] = src[col];
+        sbuf[threadIdx.y][threadIdx.x] = unary_op(src[col]);
       }
       __syncthreads();
 
       float* line = &sbuf[threadIdx.y][0];
       for(unsigned s = 16; s > 1; s >>= 1) {
         if(row < size[1] && threadIdx.x < s) {
-          line[threadIdx.x] = op(line[threadIdx.x], line[threadIdx.x + s]);
+          line[threadIdx.x] = binary_op(line[threadIdx.x], line[threadIdx.x + s]);
         }
         __syncthreads();
       }
       if(reducing) {
-        sbuf[threadIdx.x][0] = op(sbuf[threadIdx.x][0], sbuf[threadIdx.x][1]);
-        acc = op(acc, sbuf[threadIdx.x][0]);
+        sbuf[threadIdx.x][0] = binary_op(sbuf[threadIdx.x][0], sbuf[threadIdx.x][1]);
+        acc = binary_op(acc, sbuf[threadIdx.x][0]);
       }
       __syncthreads();
     }
@@ -417,8 +419,9 @@ __global__ void THCudaTensor_kernel_reduceInnermostDim(float *tgt, float *src_,
 
 
 
-template<class Op>
-__host__ void THCudaTensor_reduceInnermostDim(THCudaTensor *tgt, THCudaTensor *src, Op op, float init)
+template<class UnaryFunction, class BinaryFunction>
+__host__ void THCudaTensor_transformReduceInnermostDim(THCudaTensor *tgt, THCudaTensor *src,
+        UnaryFunction unary_op, BinaryFunction binary_op, float init)
 {
   dim4 src_stride(0);
   dim4 tgt_stride(0);
@@ -437,8 +440,8 @@ __host__ void THCudaTensor_reduceInnermostDim(THCudaTensor *tgt, THCudaTensor *s
   unsigned maxGridDim = 1024; // anything < 64k is fine. The choice has no impact on performance.
   dim3 grid(min(maxGridDim, size[2]), min(maxGridDim, nBlockPerRow), min(maxGridDim, size[3]));
 
-  THCudaTensor_kernel_reduceInnermostDim<<<grid, threads>>>(THCudaTensor_data(tgt),
-          THCudaTensor_data(src), src_stride, tgt_stride, size, op, init);
+  THCudaTensor_kernel_transformReduceInnermostDim<<<grid, threads>>>(THCudaTensor_data(tgt),
+          THCudaTensor_data(src), src_stride, tgt_stride, size, unary_op, binary_op, init);
   cudaError errcode = cudaGetLastError();
   if(errcode != cudaSuccess) {
     THError(cudaGetErrorString(errcode));
@@ -446,8 +449,9 @@ __host__ void THCudaTensor_reduceInnermostDim(THCudaTensor *tgt, THCudaTensor *s
 }
 
 
-template<class Op>
-void THCudaTensor_reduceDim(THCudaTensor *self_, THCudaTensor *src, long dimension, Op op, float init)
+template<class UnaryFunction, class BinaryFunction>
+void THCudaTensor_transformReduceDim(THCudaTensor *self_, THCudaTensor *src,
+        long dimension, UnaryFunction unary_op, BinaryFunction binary_op, float init)
 {
   THArgCheck(dimension >= 0 && dimension < THCudaTensor_nDimension(src), 3, "dimension out of range");
   THArgCheck(THCudaTensor_nDimension(src) <= 4, 2, "too many dimensions (>4)");
@@ -461,15 +465,21 @@ void THCudaTensor_reduceDim(THCudaTensor *self_, THCudaTensor *src, long dimensi
   src = THCudaTensor_newContiguous(src);
 
   if(dimension == THCudaTensor_nDimension(src)-1) {
-    THCudaTensor_reduceInnermostDim(self, src, op, init);
+    THCudaTensor_transformReduceInnermostDim(self, src, unary_op, binary_op, init);
   } else {
-    THCudaTensor_reduceOuterDim(self, src, dimension, op, init);
+    THCudaTensor_transformReduceOuterDim(self, src, dimension, unary_op, binary_op, init);
   }
 
   THCudaTensor_free(src);
   THCudaTensor_freeCopyTo(self, self_);
 }
 
+
+template<class BinaryFunction>
+void THCudaTensor_reduceDim(THCudaTensor *self_, THCudaTensor *src, long dimension, BinaryFunction binary_op, float init)
+{
+  THCudaTensor_transformReduceDim(self_, src, dimension, thrust::identity<float>(), binary_op, init);
+}
 
 
 void THCudaTensor_sum(THCudaTensor *self, THCudaTensor *src, long dimension)

--- a/extra/cuda/lib/THC/THCTensorMath.h
+++ b/extra/cuda/lib/THC/THCTensorMath.h
@@ -67,7 +67,8 @@ TH_API void THCudaTensor_neTensor(THCudaTensor *self_, THCudaTensor *src1, THCud
 TH_API float THCudaTensor_meanall(THCudaTensor *self);
 TH_API float THCudaTensor_varall(THCudaTensor *self);
 TH_API float THCudaTensor_stdall(THCudaTensor *self);
-TH_API float THCudaTensor_norm(THCudaTensor *self, float value);
+TH_API float THCudaTensor_normall(THCudaTensor *self, float value);
+TH_API void  THCudaTensor_norm(THCudaTensor* self, THCudaTensor* src, float value, long dimension);
 TH_API float THCudaTensor_dist(THCudaTensor *self, THCudaTensor *src, float value);
 
 TH_API void THCudaTensor_rand(THCudaTensor *r_, THLongStorage *size);

--- a/extra/cuda/pkg/cutorch/TensorMath.lua
+++ b/extra/cuda/pkg/cutorch/TensorMath.lua
@@ -381,10 +381,15 @@ for _,name in ipairs({"mean", "var", "std"}) do
 end
 
 interface:wrap("norm",
-               cname("norm"),
+               cname("normall"),
                      {{name="CudaTensor"},
                       {name="float", default=2},
-                      {name="float", creturned=true}})
+                      {name="float", creturned=true}},
+               cname("norm"),
+                     {{name="CudaTensor", default=true, returned=true},
+                      {name="CudaTensor"},
+                      {name="float"},
+                      {name="index"}})
 
 interface:wrap("dist",
                cname("dist"),

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1179,19 +1179,33 @@ void THTensor_(norm)(THTensor *r_, THTensor *t, real value, int dimension)
   THTensor_(resize)(r_, dim, NULL);
   THLongStorage_free(dim);
 
-  TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
-                       accreal sum = 0;
-                       long i;
-                       for(i = 0; i < t_size; i++)
-                         sum += pow(fabs(t_data[i*t_stride]), value);
-                       *r__data = pow(sum, 1.0/value);)
+  if(value == 0) {
+    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
+                         accreal sum = 0;
+                         long i;
+                         for(i = 0; i < t_size; i++)
+                           sum += t_data[i*t_stride] != 0.0;
+                         *r__data = sum;)
+  } else {
+    TH_TENSOR_DIM_APPLY2(real, t, real, r_, dimension,
+                         accreal sum = 0;
+                         long i;
+                         for(i = 0; i < t_size; i++)
+                           sum += pow(fabs(t_data[i*t_stride]), value);
+                         *r__data = pow(sum, 1.0/value);)
+  }
 }
 
 accreal THTensor_(normall)(THTensor *tensor, real value)
 { 
   accreal sum = 0;
-  TH_TENSOR_APPLY(real, tensor, sum += pow(fabs(*tensor_data), value););
-  return pow(sum, 1.0/value);
+  if(value == 0) {
+    TH_TENSOR_APPLY(real, tensor, sum += *tensor_data != 0.0;);
+    return sum;
+  } else {
+    TH_TENSOR_APPLY(real, tensor, sum += pow(fabs(*tensor_data), value););
+    return pow(sum, 1.0/value);
+  }
 }
 
 accreal THTensor_(dist)(THTensor *tensor, THTensor *src, real value)

--- a/pkg/torch/dok/maths.dok
+++ b/pkg/torch/dok/maths.dok
@@ -1021,6 +1021,8 @@ a specific dimension ''d'', in **descending** order.
 
 ''y=torch.norm(x,p)'' returns the p-norm of the tensor x. 
 
+''y=torch.norm(x,p,dim)'' returns the p-norms of the tensor x computed over the dimension dim.
+
 ====  torch.dist(x,y)        ====
 {{anchor:torch.dist}}
 


### PR DESCRIPTION
This series of commits fixes two issues:
- dimension-wise norm computations now work for CudaTensors
- 0-norm computed correctly for both regular tensors and CudaTensors
