### PR TITLE
Add dev/ folder to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ ADD_SUBDIRECTORY(pkg)
 # Torch extra packages
 ADD_SUBDIRECTORY(extra)
 
+# Torch extra packages
+ADD_SUBDIRECTORY(dev)
+
 # External packages support
 INCLUDE(TorchExports)
 


### PR DESCRIPTION
The [installation documentation](http://www.torch.ch/manual/install/index#devpackages) specifies that

>  Packages in dev are all compiled in the same way that the ones in packages sub-directory. We prefer to have this directory to make a clear difference between official packages and development packages.

However, it seems that `dev` is ignored by torch's make. The current patch fixes this. Or is `dev` now deprecated?
