### PR TITLE
Fix bug in testwrap with basic types and returned=true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ ADD_SUBDIRECTORY(pkg)
 # Torch extra packages
 ADD_SUBDIRECTORY(extra)
 
+# Torch extra packages
+ADD_SUBDIRECTORY(dev)
+
 # External packages support
 INCLUDE(TorchExports)
 

--- a/dev/testwrap/CMakeLists.txt
+++ b/dev/testwrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 FIND_PACKAGE(Torch REQUIRED)
-SET(src testwrap.c THTestWrap.h THTestWrap.c)
-FILE(GLOB luasrc testwrap.lua)
+SET(src testwrap_wrap.c THTestWrap.h THTestWrap.c)
+FILE(GLOB luasrc init.lua testwrap_wrap.lua)
 
-ADD_TORCH_WRAP(testwrap_wrap testwrap.lua)
+ADD_TORCH_WRAP(testwrap_wrap testwrap_wrap.lua)
 
 ADD_TORCH_PACKAGE(testwrap "${src}" "${luasrc}" "Tests for wrap.lua")
 TARGET_LINK_LIBRARIES(testwrap luaT TH)

--- a/dev/testwrap/CMakeLists.txt
+++ b/dev/testwrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+FIND_PACKAGE(Torch REQUIRED)
+SET(src testwrap.c THTestWrap.h THTestWrap.c)
+FILE(GLOB luasrc testwrap.lua)
+
+ADD_TORCH_WRAP(testwrap_wrap testwrap.lua)
+
+ADD_TORCH_PACKAGE(testwrap "${src}" "${luasrc}" "Tests for wrap.lua")
+TARGET_LINK_LIBRARIES(testwrap luaT TH)

--- a/dev/testwrap/THTestWrap.c
+++ b/dev/testwrap/THTestWrap.c
@@ -6,10 +6,10 @@
     *a = 19;
     *b = 83;
 } */
-void THTestWrap_onedouble(double * a) {
+void THTestWrap_ReturnOneDouble(double * a) {
     *a = 19;
 }
 
-double THTestWrap_onedoublecreturned() {
+double THTestWrap_CReturnOneDouble() {
     return 19;
 }

--- a/dev/testwrap/THTestWrap.c
+++ b/dev/testwrap/THTestWrap.c
@@ -1,0 +1,15 @@
+#include "THGeneral.h"
+#include "THTestWrap.h"
+
+/* DO NOT RUN
+ * void THTestWrap_twodouble(double * a, double * b) {
+    *a = 19;
+    *b = 83;
+} */
+void THTestWrap_onedouble(double * a) {
+    *a = 19;
+}
+
+double THTestWrap_onedoublecreturned() {
+    return 19;
+}

--- a/dev/testwrap/THTestWrap.c
+++ b/dev/testwrap/THTestWrap.c
@@ -1,11 +1,6 @@
 #include "THGeneral.h"
 #include "THTestWrap.h"
 
-/* DO NOT RUN
- * void THTestWrap_twodouble(double * a, double * b) {
-    *a = 19;
-    *b = 83;
-} */
 void THTestWrap_ReturnOneDouble(double * a) {
     *a = 19;
 }
@@ -13,3 +8,12 @@ void THTestWrap_ReturnOneDouble(double * a) {
 double THTestWrap_CReturnOneDouble() {
     return 19;
 }
+
+void THTestWrap_ReturnOneIndex(long * a) {
+    *a = 19;
+}
+
+void THTestWrap_ReturnOneBoolean(int * a) {
+    *a = 1;
+}
+

--- a/dev/testwrap/THTestWrap.h
+++ b/dev/testwrap/THTestWrap.h
@@ -1,0 +1,9 @@
+#ifndef TH_TESTWRAP_INC
+#define TH_TESTWRAP_INC
+
+#include "THGeneral.h"
+
+//void THTestWrap_twodouble(double * a, double * b);
+//void THTestWrap_onedouble(double * a);
+double THTestWrap_onedoublecreturned();
+#endif

--- a/dev/testwrap/THTestWrap.h
+++ b/dev/testwrap/THTestWrap.h
@@ -3,6 +3,6 @@
 
 #include "THGeneral.h"
 
-//void THTestWrap_ReturnOneDouble(double * a);
+void THTestWrap_ReturnOneDouble(double * a);
 double THTestWrap_CReturnOneDouble();
 #endif

--- a/dev/testwrap/THTestWrap.h
+++ b/dev/testwrap/THTestWrap.h
@@ -3,7 +3,6 @@
 
 #include "THGeneral.h"
 
-//void THTestWrap_twodouble(double * a, double * b);
-//void THTestWrap_onedouble(double * a);
-double THTestWrap_onedoublecreturned();
+//void THTestWrap_ReturnOneDouble(double * a);
+double THTestWrap_CReturnOneDouble();
 #endif

--- a/dev/testwrap/THTestWrap.h
+++ b/dev/testwrap/THTestWrap.h
@@ -5,4 +5,7 @@
 
 void THTestWrap_ReturnOneDouble(double * a);
 double THTestWrap_CReturnOneDouble();
+void THTestWrap_ReturnOneIndex(long * a);
+void THTestWrap_ReturnOneBoolean(int * a);
+
 #endif

--- a/dev/testwrap/init.lua
+++ b/dev/testwrap/init.lua
@@ -1,23 +1,2 @@
 require 'libtestwrap'
 testwrap = {}
-
-local tester = torch.Tester()
-
-function testwrap.testCReturn()
-    local a = libtestwrap.CReturnOneDouble()
-    tester:asserteq(a, 19, 'Wrong number returned')
-end
-
-
-function testwrap.testReturn()
-    local a = libtestwrap.ReturnOneDouble()
-    tester:asserteq(a, 19, 'Wrong number returned')
-end
-
-tester:add(testwrap)
-tester:run()
-
--- Add the tester to package to allow reruns
-testwrap.tester = tester;
-
-return testwrap

--- a/dev/testwrap/init.lua
+++ b/dev/testwrap/init.lua
@@ -1,9 +1,17 @@
 require 'libtestwrap'
-
 testwrap = {}
 
-function testwrap.hello() 
-    print('hello world')
+local tester = torch.Tester()
+
+function testwrap.testCReturn()
+    local a = libtestwrap.CReturnOneDouble()
+    tester:asserteq(a, 19, 'Wrong number returned')
 end
+
+tester:add(testwrap)
+tester:run()
+
+-- Add the tester to package to allow reruns
+testwrap.tester = tester;
 
 return testwrap

--- a/dev/testwrap/init.lua
+++ b/dev/testwrap/init.lua
@@ -8,6 +8,12 @@ function testwrap.testCReturn()
     tester:asserteq(a, 19, 'Wrong number returned')
 end
 
+
+function testwrap.testReturn()
+    local a = libtestwrap.ReturnOneDouble()
+    tester:asserteq(a, 19, 'Wrong number returned')
+end
+
 tester:add(testwrap)
 tester:run()
 

--- a/dev/testwrap/init.lua
+++ b/dev/testwrap/init.lua
@@ -1,0 +1,9 @@
+require 'libtestwrap'
+
+testwrap = {}
+
+function testwrap.hello() 
+    print('hello world')
+end
+
+return testwrap

--- a/dev/testwrap/testwrap.lua
+++ b/dev/testwrap/testwrap.lua
@@ -1,0 +1,40 @@
+local interface = wrap.CInterface.new()
+
+interface:print(
+   [[
+#include "luaT.h"
+#include "TH.h"
+#include "THTestWrap.h"
+   ]])
+
+--[[
+interface:wrap('wraptwodouble',
+               'THTestWrap_twodouble',
+               {{name="long"},
+               {name="long"}
+           })
+
+interface:wrap('wraponedouble',
+               'THTestWrap_onedouble',
+               {{name="long"}}
+           )
+--]]
+interface:wrap('wraponedoublecreturned',
+               'THTestWrap_onedoublecreturned',
+               {{name="long", creturned=true}}
+           )
+
+interface:register("testwrap__")
+
+interface:print(
+   [[
+int luaopen_libtestwrap(lua_State *L)
+{
+
+  luaL_register(L, "libtestwrap", testwrap__);
+
+  return 1;
+}
+   ]])
+
+interface:tofile(arg[1])

--- a/dev/testwrap/testwrap_wrap.lua
+++ b/dev/testwrap/testwrap_wrap.lua
@@ -17,7 +17,7 @@ interface:wrap('wraptwodouble',
 --]]
 interface:wrap('ReturnOneDouble',
                'THTestWrap_ReturnOneDouble',
-               {{name="double", returned=true}}
+               {{name="double", returned=true, invisible=true, default=0}}
            )
 
 interface:wrap('CReturnOneDouble',

--- a/dev/testwrap/testwrap_wrap.lua
+++ b/dev/testwrap/testwrap_wrap.lua
@@ -14,11 +14,12 @@ interface:wrap('wraptwodouble',
                {name="long"}
            })
 
-interface:wrap('wraponedouble',
-               'THTestWrap_onedouble',
-               {{name="long"}}
-           )
 --]]
+interface:wrap('ReturnOneDouble',
+               'THTestWrap_ReturnOneDouble',
+               {{name="double", returned=true}}
+           )
+
 interface:wrap('CReturnOneDouble',
                'THTestWrap_CReturnOneDouble',
                {{name="double", creturned=true}}

--- a/dev/testwrap/testwrap_wrap.lua
+++ b/dev/testwrap/testwrap_wrap.lua
@@ -19,9 +19,9 @@ interface:wrap('wraponedouble',
                {{name="long"}}
            )
 --]]
-interface:wrap('wraponedoublecreturned',
-               'THTestWrap_onedoublecreturned',
-               {{name="long", creturned=true}}
+interface:wrap('CReturnOneDouble',
+               'THTestWrap_CReturnOneDouble',
+               {{name="double", creturned=true}}
            )
 
 interface:register("testwrap__")

--- a/dev/testwrap/testwrap_wrap.lua
+++ b/dev/testwrap/testwrap_wrap.lua
@@ -25,6 +25,17 @@ interface:wrap('CReturnOneDouble',
                {{name="double", creturned=true}}
            )
 
+interface:wrap('ReturnOneIndex',
+               'THTestWrap_ReturnOneIndex',
+               {{name="index", returned=true, invisible=true, default=0}}
+           )
+
+interface:wrap('ReturnOneBoolean',
+               'THTestWrap_ReturnOneBoolean',
+               {{name="boolean", returned=true, invisible=true, default=0}}
+           )
+
+
 interface:register("testwrap__")
 
 interface:print(

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -402,16 +402,26 @@ function torchtest.BugInAssertTableEq()
    mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different')
 end
 
+local tw = require('libtestwrap')
+
 function torchtest.WrapBasicTypeCReturn()
-    local tw = require('libtestwrap')
     local a = tw.CReturnOneDouble()
     mytester:asserteq(a, 19, 'Wrong number returned')
 end
 
 function torchtest.WrapBasicTypeReturn()
-    local tw = require('libtestwrap')
     local a = tw.ReturnOneDouble()
     mytester:asserteq(a, 19, 'Wrong number returned')
+end
+
+function torchtest.WrapBooleanReturn()
+    local a = tw.ReturnOneBoolean()
+    mytester:asserteq(a, true, 'Wrong boolean returned')
+end
+
+function torchtest.WrapIndexReturn()
+    local a = tw.ReturnOneIndex()
+    mytester:asserteq(a, 20, 'Wrong index returned')
 end
 
 

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -402,6 +402,19 @@ function torchtest.BugInAssertTableEq()
    mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different')
 end
 
+function torchtest.WrapBasicTypeCReturn()
+    local tw = require('libtestwrap')
+    local a = tw.CReturnOneDouble()
+    mytester:asserteq(a, 19, 'Wrong number returned')
+end
+
+function torchtest.WrapBasicTypeReturn()
+    local tw = require('libtestwrap')
+    local a = tw.ReturnOneDouble()
+    mytester:asserteq(a, 19, 'Wrong number returned')
+end
+
+
 function torch.test()
    math.randomseed(os.time())
    mytester = torch.Tester()

--- a/pkg/wrap/types.lua
+++ b/pkg/wrap/types.lua
@@ -335,6 +335,9 @@ for _,typename in ipairs({"real", "unsigned char", "char", "short", "int", "long
       declare = function(arg)
                    -- if it is a number we initialize here
                    local default = tonumber(interpretdefaultvalue(arg)) or 0
+                   if arg.returned and (not arg.invisible) then
+                       error(string.format('Returned arguments of type *%s* must have invisible=true', typename))
+                   end
                    return string.format("%s arg%d = %d;", typename, arg.i, tonumber(default))
                 end,
 

--- a/pkg/wrap/types.lua
+++ b/pkg/wrap/types.lua
@@ -369,13 +369,10 @@ for _,typename in ipairs({"real", "unsigned char", "char", "short", "int", "long
                 end,
       
       precall = function(arg)
-                   if arg.returned then
-                      return string.format('lua_pushnumber(L, (lua_Number)arg%d);', arg.i)
-                   end
                 end,
       
       postcall = function(arg)
-                    if arg.creturned then
+                    if arg.creturned or arg.returned then
                        return string.format('lua_pushnumber(L, (lua_Number)arg%d);', arg.i)
                     end
                  end

--- a/pkg/wrap/types.lua
+++ b/pkg/wrap/types.lua
@@ -283,6 +283,9 @@ wrap.argtypes.index = {
    declare = function(arg)
                 -- if it is a number we initialize here
                 local default = tonumber(interpretdefaultvalue(arg)) or 1
+                if arg.returned and (not arg.invisible) then
+                    error('Returned arguments of type *index* must have invisible=true')
+                end
                 return string.format("long arg%d = %d;", arg.i, tonumber(default)-1)
            end,
 
@@ -305,7 +308,11 @@ wrap.argtypes.index = {
           end,
 
    carg = function(arg)
-             return string.format('arg%d', arg.i)
+            if arg.returned then
+               return string.format('&arg%d', arg.i)
+            else
+               return string.format('arg%d', arg.i)
+            end
           end,
 
    creturn = function(arg)
@@ -313,13 +320,10 @@ wrap.argtypes.index = {
              end,
 
    precall = function(arg)
-                if arg.returned then
-                   return string.format('lua_pushnumber(L, (lua_Number)arg%d+1);', arg.i)
-                end
              end,
 
    postcall = function(arg)
-                 if arg.creturned then
+                 if arg.creturned or arg.returned then
                     return string.format('lua_pushnumber(L, (lua_Number)arg%d+1);', arg.i)
                  end
               end
@@ -393,6 +397,9 @@ wrap.argtypes.boolean = {
    declare = function(arg)
                 -- if it is a number we initialize here
                 local default = tonumber(interpretdefaultvalue(arg)) or 0
+                if arg.returned and (not arg.invisible) then
+                    error('Returned arguments of type *boolean* must have invisible=true')
+                end
                 return string.format("int arg%d = %d;", arg.i, tonumber(default))
              end,
 
@@ -415,7 +422,11 @@ wrap.argtypes.boolean = {
           end,
 
    carg = function(arg)
-             return string.format('arg%d', arg.i)
+             if arg.returned then
+                return string.format('&arg%d', arg.i)
+             else
+                return string.format('arg%d', arg.i)
+             end
           end,
 
    creturn = function(arg)
@@ -423,13 +434,10 @@ wrap.argtypes.boolean = {
              end,
 
    precall = function(arg)
-                if arg.returned then
-                   return string.format('lua_pushboolean(L, arg%d);', arg.i)
-                end
              end,
 
    postcall = function(arg)
-                 if arg.creturned then
+                 if arg.creturned or arg.returned then
                     return string.format('lua_pushboolean(L, arg%d);', arg.i)
                  end
               end

--- a/pkg/wrap/types.lua
+++ b/pkg/wrap/types.lua
@@ -357,7 +357,11 @@ for _,typename in ipairs({"real", "unsigned char", "char", "short", "int", "long
              end,
       
       carg = function(arg)
-                return string.format('arg%d', arg.i)
+                if arg.returned then
+                   return string.format('&arg%d', arg.i)
+                else
+                   return string.format('arg%d', arg.i)
+                end
              end,
 
       creturn = function(arg)


### PR DESCRIPTION
# Problem

When using `wrap.lua`, it was so far impossible to have a basic type (e.g. double) as a `returned = true` argument. It could only be `creturned = true`, which was problematic when more than one value needed to be returned (as e.g. in issue andresy#129).

This pull-request fixes this. I realize that with FFI, C functions are much easier to wrap, but for uniformity with the rest of the code-base, I wanted to stick to `wrap.lua` when developping andresy#129.
# Implemented solution
## Pass pointers 

When an arugment of basic type has `returned = true`, a pointer is passed to the C function, so that it can use it as an output argument. 
## Push on stack at postcall, not precall

I also removed the way such returned basic type arguments were pushed on the stack at <b>pre</b>call. Instead, I now push them on stack at <b>post</b>call, just like `creturned=true` arugment. I did 
## Force requirement for invisible

I had to require that such arguments were also `invisible = true`, because they would otherwise be counted in `narg`, and thus mess the check. I could have modified the check to ignore the returned arguments of this type, and prevent them from being stacked by the caller, but that would make too deep modifications: I'm not comfortable enough with the rest of `wrap.lua` to ensure that it would not clash with the smart things done for non-basic types.

An alternative way would be to automatically turn them invisible.
## Added a package `testwrap` for the tests, in `/dev`

I have added corresponding unit tests in package `dev/testwrap`. However, this relies on pull-request andresy#133 being merged. Alternatively, I will be happy to move those tests to any folder you suggest. 
