### PR TITLE
Added CMake switch for lua or torch package paths

### DIFF
--- a/cmake/TorchPaths.cmake
+++ b/cmake/TorchPaths.cmake
@@ -27,8 +27,16 @@ SET(Torch_INSTALL_HTML_SUBDIR "share/torch/html" CACHE PATH
 SET(Torch_INSTALL_CMAKE_SUBDIR "share/cmake/torch" CACHE PATH
   "Install dir for .cmake files (relative to Torch_INSTALL_PREFIX)")
 
-SET(Torch_INSTALL_LUA_PATH_SUBDIR "share/torch/lua" CACHE PATH
+OPTION(WITH_LUA_PACKAGE_PATH "Use the package path from lua instead of the one from Torch" OFF)
+
+IF(WITH_LUA_PACKAGE_PATH)
+  SET(Torch_PACKAGE_PATH "lua/5.1")
+ELSE(WITH_LUA_PACKAGE_PATH)
+  SET(Torch_PACKAGE_PATH "torch/lua")
+ENDIF(WITH_LUA_PACKAGE_PATH)
+
+SET(Torch_INSTALL_LUA_PATH_SUBDIR "share/${Torch_PACKAGE_PATH}" CACHE PATH
   "Install dir for Lua packages files (relative to Torch_INSTALL_PREFIX)")
 
-SET(Torch_INSTALL_LUA_CPATH_SUBDIR "lib/torch/lua" CACHE PATH
+SET(Torch_INSTALL_LUA_CPATH_SUBDIR "lib/${Torch_PACKAGE_PATH}" CACHE PATH
   "Install dir for Lua C packages files (relative to Torch_INSTALL_PREFIX)")


### PR DESCRIPTION
This allows one to build torch for use with luarocks without building torch itself as a rock. The cmake option WITH_LUA_PACKAGE_PATH needs to be set from the command-line to have an effect. This is because the actual full package paths are cached and should still be editable by the user when doing manual configuration using cmake-gui or ccmake.

The default is to use the existing torch package paths.
