### PR TITLE
Cuda expand

### DIFF
--- a/extra/cuda/lib/THC/THCTensorCopy.cu
+++ b/extra/cuda/lib/THC/THCTensorCopy.cu
@@ -37,10 +37,10 @@ __global__ void THCudaTensor_kernel_copy(float *dst,
 
   long i_start = threadIdx.x * src_st[src_dim-1];
   long i_step = blockDim.x * src_st[src_dim-1];
-  long i_end = innerdim * src_st[src_dim-1];
 
   long o_start = threadIdx.x * dst_st[dst_dim-1];
   long o_step = blockDim.x * dst_st[dst_dim-1];
+  long o_end = innerdim * dst_st[dst_dim-1];
 
   if ( ((k+1) * innerdim) <= n_elem) // too safe
   {
@@ -60,7 +60,7 @@ __global__ void THCudaTensor_kernel_copy(float *dst,
       src_rest = src_rest % src_sz[dim];
     }
 
-    for (int i=i_start, o=o_start; i<i_end; i+=i_step, o+=o_step) {
+    for (int i=i_start, o=o_start; o<o_end; i+=i_step, o+=o_step) {
       dst[dst_idx + o] = src[src_idx + i];
     }
   }

--- a/extra/cuda/pkg/cutorch/Tensor.lua
+++ b/extra/cuda/pkg/cutorch/Tensor.lua
@@ -53,3 +53,10 @@ for _,func in ipairs({'addmv',
                                end
                             end      
 end
+
+do
+    local metatable = torch.getmetatable('torch.CudaTensor')
+    for _,func in pairs{'expand', 'expandAs'} do
+        rawset(metatable, func, torch[func])
+    end
+end

--- a/extra/cuda/pkg/cutorch/test/test.lua
+++ b/extra/cuda/pkg/cutorch/test/test.lua
@@ -1,0 +1,35 @@
+require 'cutorch'
+
+local tester
+local test = {}
+local msize = 100
+
+
+local function compareFloatAndCuda(x, fn, ...)
+   x_cpu    = x:float()
+   x_cuda   = x_cpu:cuda()
+   tester:assertne(x_cuda[fn], nil,
+      string.format("Missing function CudaTensor.%s", fn))
+   res_cpu  = x_cpu[fn](x, ...)
+   res_cuda = x_cuda[fn](x_cuda, ...):float()
+   local tolerance = 1e-5
+   tester:assertTensorEq(res_cpu, res_cuda, tolerance,
+      string.format("Divergent results between CPU and CUDA for function '%s'", fn)) 
+end
+
+
+function test.expand()
+   local x = torch.FloatTensor():rand(msize, 1)
+   compareFloatAndCuda(x, 'expand', msize, msize)
+
+   x = torch.FloatTensor():rand(1, msize)
+   compareFloatAndCuda(x, 'expand', msize, msize)
+end
+
+
+function cutorch.test()
+   math.randomseed(os.time())
+   tester = torch.Tester()
+   tester:add(test)
+   tester:run()
+end


### PR DESCRIPTION
This series of commits adds CudaTorch.expand and CudaTorch.expandAs. The cuda-to-cuda copy had to be modified to accommodate this.
