### PR TITLE
Cuda mean

### DIFF
--- a/extra/cuda/lib/THC/THCTensorMath.cu
+++ b/extra/cuda/lib/THC/THCTensorMath.cu
@@ -790,6 +790,13 @@ float THCudaTensor_meanall(THCudaTensor *self)
   return THCudaTensor_sumall(self)/THCudaTensor_nElement(self);
 }
 
+void
+THCudaTensor_mean(THCudaTensor *self, THCudaTensor *src, long dim)
+{
+  THCudaTensor_sum(self, src, dim);
+  THCudaTensor_div(self, THCudaTensor_nElement(src) / THCudaTensor_size(src, dim));
+}
+
 struct square_functor
 {
   const float mean;

--- a/extra/cuda/lib/THC/THCTensorMath.h
+++ b/extra/cuda/lib/THC/THCTensorMath.h
@@ -65,6 +65,7 @@ TH_API void THCudaTensor_eqTensor(THCudaTensor *self_, THCudaTensor *src1, THCud
 TH_API void THCudaTensor_neTensor(THCudaTensor *self_, THCudaTensor *src1, THCudaTensor *src2);
 
 TH_API float THCudaTensor_meanall(THCudaTensor *self);
+TH_API void  THCudaTensor_mean(THCudaTensor *self, THCudaTensor *src, long dim);
 TH_API float THCudaTensor_varall(THCudaTensor *self);
 TH_API float THCudaTensor_stdall(THCudaTensor *self);
 TH_API float THCudaTensor_normall(THCudaTensor *self, float value);

--- a/extra/cuda/pkg/cutorch/TensorMath.lua
+++ b/extra/cuda/pkg/cutorch/TensorMath.lua
@@ -373,7 +373,17 @@ for _,f in ipairs({{name='exponential'}}) do
                    {name="float", default=f.a}})
 end
 
-for _,name in ipairs({"mean", "var", "std"}) do
+
+interface:wrap("mean",
+              cname("meanall"),
+              {{name="CudaTensor"},
+               {name="float", creturned=true}},
+              cname("mean"),
+              {{name="CudaTensor", default=true, returned=true},
+               {name="CudaTensor"},
+               {name="index"}})
+
+for _,name in ipairs({"var", "std"}) do
    interface:wrap(name,
                   cname(name .. "all"),
                   {{name="CudaTensor"},

--- a/pkg/torch/dok/maths.dok
+++ b/pkg/torch/dok/maths.dok
@@ -1000,7 +1000,7 @@ a specific dimension ''d'', in **descending** order.
 ''y=torch.sum(x,2)'' performs the sum operation for each row and
 ''y=torch.sum(x,n)'' performs the sum operation over the dimension n.
 
-====  [res] torch.var([res,] x [,flag] [,dim]) ====
+====  [res] torch.var([res,] x [,dim] [,flag]) ====
 {{anchor:torch.var}}
 
 ''y=torch.var(x)'' returns the variance of the elements of x.


### PR DESCRIPTION
This adds CudaTensor.mean of the form y = torch.mean(x,dim).
I added tests for mean, var, and std, but realized the latter two will be a bit harder to implement, so haven't implemented these yet.
