### PR TITLE
Let print() to print a new line

### DIFF
--- a/exe/torch-exe/torch-env.lua
+++ b/exe/torch-exe/torch-env.lua
@@ -177,7 +177,6 @@ end
 local ndepth = 4
 local print_old=print
 local function print_new(...)
-   local objs = {...}
    local function printrecursive(obj,depth)
       local depth = depth or 0
       local tab = depth*4
@@ -220,6 +219,9 @@ local function print_new(...)
       else 
          printrecursive(obj) 
       end
+   end
+   if select('#',...) == 0 then
+      print_old()
    end
 end
 


### PR DESCRIPTION
The print() with no arguments should print a new line.
I restore this behavior.

Before the pull request:

```
t7> print()
t7> 
```

After:

```
t7> print()

t7> 
```
