### PR TITLE
Update index.dok

### DIFF
--- a/pkg/gnuplot/dok/index.dok
+++ b/pkg/gnuplot/dok/index.dok
@@ -263,7 +263,7 @@ Sets the properties of axis for the current plot.
   * ''image'' : scales the axis aspect ratio so that a circle is drawn as circle.
   * ''equal'' : same as ''image''.
   * ''fill'' : resets the aspect ratio of the plot to original values so that it fills up the canvas as good as possible.
-  * {xmin,xmax,ymin,ymax} : Sets the limits of x and y axes.
+  * {xmin,xmax,ymin,ymax} : Sets the limits of x and y axes. Use an empty string (2 apostophes in a row) if you want to keep the current value.
 
 ====  gnuplot.raw(command) ====
 {{anchor:gnuplot.raw}}


### PR DESCRIPTION
Added

```
Use an empty string (2 apostophes in a row) if you want to keep the current value.
```

for keeping the current value of `{xmin,xmax,ymin,ymax}` in `gnuplot.axis` documentation. Actually, I don't know how to write the `''`, since these are a command in the documentation..
