### PR TITLE
Add support for QT term in gnuplot

### DIFF
--- a/pkg/gnuplot/gnuplot.lua
+++ b/pkg/gnuplot/gnuplot.lua
@@ -215,16 +215,22 @@ local function getgnuplotdefaultterm(os)
       return  'windows'
    elseif os == 'linux' and gnuplothasterm('wxt') then
       return  'wxt'
+   elseif os == 'linux' and gnuplothasterm('qt') then
+      return  'qt'
    elseif os == 'linux' and gnuplothasterm('x11') then
       return  'x11'
    elseif os == 'freebsd' and gnuplothasterm('wxt') then
       return  'wxt'
+   elseif os == 'freebsd' and gnuplothasterm('qt') then
+      return  'qt'
    elseif os == 'freebsd' and gnuplothasterm('x11') then
       return  'x11'
    elseif os == 'mac' and gnuplothasterm('aqua') then
       return  'aqua'
    elseif os == 'mac' and gnuplothasterm('wxt') then
       return  'wxt'
+   elseif os == 'mac' and gnuplothasterm('qt') then
+      return  'qt'
    elseif os == 'mac' and gnuplothasterm('x11') then
       return  'x11'
    else


### PR DESCRIPTION
This patch inserts 'qt' as terminal type for gnuplot for all OSes, with lower
precedence than 'wxt' but higher than 'x11'

Qt is a better alternative than x11, according to
[gnuplot 4.6.0 release notes](http://www.gnuplot.info/announce.4.6.0):

```
        NOTES TO PACKAGERS AND TESTERS
       ===============================

Configuration options for interactive use
-----------------------------------------

The 4.6 source code supports three primary cross-platform output modes in
addition to several platform-specific modes.

1) Cairo/pango/wxWidgets
  These terminals were introduced in version 4.4 and are now the most
  stable and full-featured option.  This set of terminals includes
  - pngcairo, pdfcairo, epscairo, and cairolatex for output to a file
  - wxt for interactive display
  This is the default configuration, but requires prior installation of
  libcairo, libpango, libcairo, libwxgtk, and related support libraries
  To disable these terminals:
      ./configure --disable-wxt --without-cairo

2) Qt
  The new qt terminal supports interactive display with menu-driven
  output to png, svg or pdf.
  Requires libqt version >= 4.5
      ./configure --enable-qt

3) X11 (the "classic" interactive interface)
  This used to be the preferred interactive interface, but the newer
  wxt and qt terminals offer nicer output and a wider range of features.
```
