### PR TITLE
Add support for PDF if gnuplot supports

### DIFF
--- a/pkg/gnuplot/dok/index.dok
+++ b/pkg/gnuplot/dok/index.dok
@@ -308,7 +308,7 @@ skipped, a new figure is created with the next consecutive id.
 {{anchor:gnuplot.epsfigure}}
 
 Creates a figure directly on the ''eps'' file given with
-''fname''. This uses ''Gnuplot'' terminal ''postscricpt eps enhanced color''.
+''fname''. This uses ''Gnuplot'' terminal ''postscript eps enhanced color''.
 
 ====  gnuplot.pdffigure(fname) ====
 {{anchor:gnuplot.pdffigure}}

--- a/pkg/gnuplot/dok/index.dok
+++ b/pkg/gnuplot/dok/index.dok
@@ -259,7 +259,8 @@ gnuplot.hist(torch.randn(100000),100)
 {{anchor:gnuplot.files.dok}}
 
 Any of the above plotting utilities can also be used for directly
-plotting into ''eps'' or ''png'' files. A final gnuplot.plotflush()
+plotting into ''eps'' or ''png'' files, or ''pdf'' files if your gnuplot
+installation allows. A final gnuplot.plotflush()
 command ensures that all output is written to the file properly.
 
 <file lua>
@@ -308,6 +309,16 @@ skipped, a new figure is created with the next consecutive id.
 
 Creates a figure directly on the ''eps'' file given with
 ''fname''. This uses ''Gnuplot'' terminal ''postscricpt eps enhanced color''.
+
+====  gnuplot.pdffigure(fname) ====
+{{anchor:gnuplot.pdffigure}}
+
+Only available if your installation of gnuplot has been compiled
+with ''pdf'' support enabled.
+
+Creates a figure directly on the ''pdf'' file given with
+''fname''. This uses ''Gnuplot'' terminal ''pdf enhanced color'',
+or ''pdfcairo enhanced color'' if available.
 
 ====  gnuplot.pngfigure(fname) ====
 {{anchor:gnuplot.pngfigure}}

--- a/pkg/gnuplot/dok/index.dok
+++ b/pkg/gnuplot/dok/index.dok
@@ -275,7 +275,7 @@ gnuplot.plotflush()
 {{anchor:gnuplot.commons.dok}}
 
 It is possible to manage multiple plots at a time, printing plots to
-png, or eps files or creating plots directly on png or eps files.
+png, eps or pdf files or creating plots directly on png or eps or pdf files.
 
 There are also several handy operations for decorating plots which are
 common to many of the plotting functions.

--- a/pkg/gnuplot/dok/index.dok
+++ b/pkg/gnuplot/dok/index.dok
@@ -325,7 +325,8 @@ flushing file based terminals.
 {{anchor:gnuplot.figprint}}
 
 Prints the current figure to the given file with name ''fname''. Only
-''png'' or ''eps'' files are supported.
+''png'' or ''eps'' files are supported by default. If your gnuplot installation
+allows, ''pdf'' files are also supported.
 
 ====  gnuplot.xlabel(label) ====
 {{anchor:gnuplot.xlabel}}

--- a/pkg/gnuplot/gnuplot.lua
+++ b/pkg/gnuplot/gnuplot.lua
@@ -678,6 +678,9 @@ function gnuplot.figprint(fname)
    elseif suffix == 'png' then
       term = 'png size "1024,768"'
    elseif suffix == 'pdf' and haspdf then
+      if not haspdf then
+          error('your installation of gnuplot does not have pdf support enabled')
+      end
       if gnuplothasterm('pdfcairo') then
           term = 'pdfcairo'
       else

--- a/pkg/gnuplot/gnuplot.lua
+++ b/pkg/gnuplot/gnuplot.lua
@@ -672,12 +672,24 @@ end
 function gnuplot.figprint(fname)
    local suffix = fname:match('.+%.(.+)')
    local term = nil
+   local haspdf = gnuplothasterm('pdf') or gnuplothasterm('pdfcairo')
    if suffix == 'eps' then
       term = 'postscript eps enhanced color'
    elseif suffix == 'png' then
       term = 'png size "1024,768"'
+   elseif suffix == 'pdf' and haspdf then
+      if gnuplothasterm('pdfcairo') then
+          term = 'pdfcairo'
+      else
+          term = 'pdf'
+      end
+      term = term .. ' enhanced color'
    else
-      error('only eps and png for figprint')
+      local errmsg = 'only eps and png'
+      if haspdf then
+          errmsg = errmsg .. ' and pdf'
+      end
+      error(errmsg ' for figprint')
    end
    writeToCurrent('set term ' .. term)
    writeToCurrent('set output \''.. fname .. '\'')

--- a/pkg/gnuplot/gnuplot.lua
+++ b/pkg/gnuplot/gnuplot.lua
@@ -669,6 +669,21 @@ function gnuplot.pngfigure(fname,n)
    return _gptable.current
 end
 
+function gnuplot.pdffigure(fname,n)
+   local haspdf = gnuplothasterm('pdf') or gnuplothasterm('pdfcairo')
+   if not haspdf then
+     error('your installation of gnuplot does not have pdf support enabled')
+   end
+   local term = nil
+   if gnuplothasterm('pdfcairo') then
+      term = 'pdfcairo enhanced color'
+   else
+      term = 'pdf enhanced color'
+   end
+   filefigure(fname,term,n)
+   return _gptable.current
+end
+
 function gnuplot.figprint(fname)
    local suffix = fname:match('.+%.(.+)')
    local term = nil


### PR DESCRIPTION
This pull-request provides both gnuplot.pdffigure() and
gnuplot.figprint('whatever.pdf'). 

If gnuplot has not been compiled with pdf support, an error
is raised when either of these functionalities are called.
Gnuplot support for pdf is enabled on OSX with homebrew using
`brew install gnu plot --pdf`

Besides, if the terminal `pdfcairo` is available, it is used instead
of the `pdf` terminal
