### PR TITLE
Speed-up qsort for sorted arrays

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -976,15 +976,22 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
 
 static void THTensor_(quicksortdescend)(real *arr, long *idx, long elements, long stride)
 {
-  long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, swap, pid;
-  real piv;
+  long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;
+  real rswap, piv;
   
   beg[0]=0; end[0]=elements;
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
     if (L<R) {
-      piv=arr[L*stride];
-      pid=idx[L*stride];
+      P=(L+R)>>1; // Choose pivot as middle element of the current block
+      piv=arr[P*stride];
+      pid=idx[P*stride];
+      rswap=arr[L*stride];
+      swap=idx[L*stride];
+      arr[L*stride]=piv;
+      idx[L*stride]=pid;
+      arr[P*stride]=rswap;
+      idx[P*stride]=swap;
       while (L<R) {
         while (arr[R*stride]<=piv && L<R)
             R--;

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -986,14 +986,36 @@ static void THTensor_(quicksortdescend)(real *arr, long *idx, long elements, lon
       piv=arr[L*stride];
       pid=idx[L*stride];
       while (L<R) {
-        while (arr[R*stride]<=piv && L<R) R--; if (L<R) {idx[L*stride]=idx[R*stride]; arr[L*stride]=arr[R*stride]; L++;}
-        while (arr[L*stride]>=piv && L<R) L++; if (L<R) {idx[R*stride]=idx[L*stride]; arr[R*stride]=arr[L*stride]; R--;} }
-      idx[L*stride]=pid; arr[L*stride]=piv; beg[i+1]=L+1; end[i+1]=end[i]; end[i++]=L;
+        while (arr[R*stride]<=piv && L<R)
+            R--;
+        if (L<R) {
+            idx[L*stride]=idx[R*stride];
+            arr[L*stride]=arr[R*stride];
+            L++;
+        }
+        while (arr[L*stride]>=piv && L<R)
+            L++;
+        if (L<R) {
+            idx[R*stride]=idx[L*stride];
+            arr[R*stride]=arr[L*stride];
+            R--;
+        }
+      }
+      idx[L*stride]=pid;
+      arr[L*stride]=piv;
+      beg[i+1]=L+1;
+      end[i+1]=end[i];
+      end[i++]=L;
       if (end[i]-beg[i]>end[i-1]-beg[i-1]) {
         swap=beg[i]; beg[i]=beg[i-1]; beg[i-1]=swap;
-        swap=end[i]; end[i]=end[i-1]; end[i-1]=swap; }}
+        swap=end[i]; end[i]=end[i-1]; end[i-1]=swap;
+      }
+    }
     else {
-      i--; }}}
+      i--;
+    }
+  }
+}
 
 void THTensor_(sort)(THTensor *rt_, THLongTensor *ri_, THTensor *t, int dimension, int descendingOrder)
 {

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -920,19 +920,28 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
    http://www.alienryderflex.com/quicksort/
    This public-domain C implementation by Darel Rex Finley.
    Thanks man :)
+
+    Updated Oct 16 2013: change choice of pivot to avoid worst-case being a pre-sorted input
 */
 #define  MAX_LEVELS  300
 static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long stride)
 {
-  long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, swap, pid;
-  real piv;
+  long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;
+  real rswap, piv;
   
   beg[0]=0; end[0]=elements;
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
     if (L<R) {
-      piv=arr[L*stride];
-      pid=idx[L*stride];
+      P=(L+R)>>1; // Choose pivot as middle element of the current block
+      piv=arr[P*stride];
+      pid=idx[P*stride];
+      rswap=arr[L*stride];
+      swap=idx[L*stride];
+      arr[L*stride]=piv;
+      idx[L*stride]=pid;
+      arr[P*stride]=rswap;
+      idx[P*stride]=swap;
       while (L<R) {
         while (arr[R*stride]>=piv && L<R)
             R--;

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -934,14 +934,36 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
       piv=arr[L*stride];
       pid=idx[L*stride];
       while (L<R) {
-        while (arr[R*stride]>=piv && L<R) R--; if (L<R) {idx[L*stride]=idx[R*stride]; arr[L*stride]=arr[R*stride]; L++;}
-        while (arr[L*stride]<=piv && L<R) L++; if (L<R) {idx[R*stride]=idx[L*stride]; arr[R*stride]=arr[L*stride]; R--;} }
-      idx[L*stride]=pid; arr[L*stride]=piv; beg[i+1]=L+1; end[i+1]=end[i]; end[i++]=L;
+        while (arr[R*stride]>=piv && L<R)
+            R--;
+        if (L<R) {
+            idx[L*stride]=idx[R*stride];
+            arr[L*stride]=arr[R*stride];
+            L++;
+        }
+        while (arr[L*stride]<=piv && L<R)
+            L++;
+        if (L<R) {
+            idx[R*stride]=idx[L*stride];
+            arr[R*stride]=arr[L*stride];
+            R--;
+        }
+      }
+      idx[L*stride]=pid;
+      arr[L*stride]=piv;
+      beg[i+1]=L+1;
+      end[i+1]=end[i];
+      end[i++]=L;
       if (end[i]-beg[i]>end[i-1]-beg[i-1]) {
         swap=beg[i]; beg[i]=beg[i-1]; beg[i-1]=swap;
-        swap=end[i]; end[i]=end[i-1]; end[i-1]=swap; }}
+        swap=end[i]; end[i]=end[i-1]; end[i-1]=swap;
+      }
+    }
     else {
-      i--; }}}
+      i--;
+    }
+  }
+}
 
 static void THTensor_(quicksortdescend)(real *arr, long *idx, long elements, long stride)
 {

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -141,18 +141,29 @@ function torchtest.sort()
    local increasing = true
    for j = 1,msize do
        for k = 2,msize do
-           increasing = increasing and (mxx[j][k-1] <= mxx[j][k])
+           increasing = increasing and (mxx[j][k-1] < mxx[j][k])
        end
    end
    mytester:assert(increasing, 'torch.sort increasing')
 
+   local seen = torch.ByteTensor(msize)
    local indicesCorrect = true
    for k = 1,msize do
+       seen:zero()
        for j = 1,msize do
            indicesCorrect = indicesCorrect and (x[k][ixx[k][j]] == mxx[k][j])
+           seen[ixx[k][j]] = 1
        end
+       indicesCorrect = indicesCorrect and (torch.sum(seen) == msize)
    end
    mytester:assert(indicesCorrect, 'torch.sort indices')
+
+   mytester:assertTensorEq(
+           torch.sort(torch.Tensor{ 50, 40, 30, 20, 10 }),
+           torch.Tensor{ 10, 20, 30, 40, 50 },
+           1e-16,
+           "torch.sort simple sort"
+       )
 
 end
 function torchtest.tril()

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -129,23 +129,21 @@ function torchtest.reshape()
    torch.reshape(mxx,x,130,23)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.reshape value')
 end
-function torchtest.sort()
+function torchtest.sortAscending()
    local x = torch.rand(msize,msize)
    local mx,ix = torch.sort(x)
    local mxx = torch.Tensor()
    local ixx = torch.LongTensor()
    torch.sort(mxx,ixx,x)
-   mytester:asserteq(maxdiff(mx,mxx),0,'torch.sort value')
-   mytester:asserteq(maxdiff(ix,ixx),0,'torch.sort index')
-
+   mytester:asserteq(maxdiff(mx,mxx),0,'torch.sort (ascending) value')
+   mytester:asserteq(maxdiff(ix,ixx),0,'torch.sort (ascending) index')
    local increasing = true
    for j = 1,msize do
        for k = 2,msize do
            increasing = increasing and (mxx[j][k-1] < mxx[j][k])
        end
    end
-   mytester:assert(increasing, 'torch.sort increasing')
-
+   mytester:assert(increasing, 'torch.sort (ascending) increasing')
    local seen = torch.ByteTensor(msize)
    local indicesCorrect = true
    for k = 1,msize do
@@ -156,15 +154,46 @@ function torchtest.sort()
        end
        indicesCorrect = indicesCorrect and (torch.sum(seen) == msize)
    end
-   mytester:assert(indicesCorrect, 'torch.sort indices')
-
+   mytester:assert(indicesCorrect, 'torch.sort (ascending) indices')
    mytester:assertTensorEq(
            torch.sort(torch.Tensor{ 50, 40, 30, 20, 10 }),
            torch.Tensor{ 10, 20, 30, 40, 50 },
            1e-16,
-           "torch.sort simple sort"
+           "torch.sort (ascending) simple sort"
        )
-
+end
+function torchtest.sortDescending()
+   local x = torch.rand(msize,msize)
+   local mx,ix = torch.sort(x,true)
+   local mxx = torch.Tensor()
+   local ixx = torch.LongTensor()
+   torch.sort(mxx,ixx,x,true)
+   mytester:asserteq(maxdiff(mx,mxx),0,'torch.sort (descending) value')
+   mytester:asserteq(maxdiff(ix,ixx),0,'torch.sort (descending) index')
+   local increasing = true
+   for j = 1,msize do
+       for k = 2,msize do
+           increasing = increasing and (mxx[j][k-1] > mxx[j][k])
+       end
+   end
+   mytester:assert(increasing, 'torch.sort (descending) decreasing')
+   local seen = torch.ByteTensor(msize)
+   local indicesCorrect = true
+   for k = 1,msize do
+       seen:zero()
+       for j = 1,msize do
+           indicesCorrect = indicesCorrect and (x[k][ixx[k][j]] == mxx[k][j])
+           seen[ixx[k][j]] = 1
+       end
+       indicesCorrect = indicesCorrect and (torch.sum(seen) == msize)
+   end
+   mytester:assert(indicesCorrect, 'torch.sort (descending) indices')
+   mytester:assertTensorEq(
+           torch.sort(torch.Tensor{ 10, 20, 30, 40, 50 },true),
+           torch.Tensor{ 50, 40, 30, 20, 10 },
+           1e-16,
+           "torch.sort (descending) simple sort"
+       )
 end
 function torchtest.tril()
    local x = torch.rand(msize,msize)

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -137,6 +137,23 @@ function torchtest.sort()
    torch.sort(mxx,ixx,x)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.sort value')
    mytester:asserteq(maxdiff(ix,ixx),0,'torch.sort index')
+
+   local increasing = true
+   for j = 1,msize do
+       for k = 2,msize do
+           increasing = increasing and (mxx[j][k-1] <= mxx[j][k])
+       end
+   end
+   mytester:assert(increasing, 'torch.sort increasing')
+
+   local indicesCorrect = true
+   for k = 1,msize do
+       for j = 1,msize do
+           indicesCorrect = indicesCorrect and (x[k][ixx[k][j]] == mxx[k][j])
+       end
+   end
+   mytester:assert(indicesCorrect, 'torch.sort indices')
+
 end
 function torchtest.tril()
    local x = torch.rand(msize,msize)

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -3,7 +3,8 @@
 require 'mathx'
 require 'gnuplot'
 
-function testSort()
+function testSort(output, descending)
+    descending = descending or false
     local pow10 = torch.linspace(1,5,10)
     local bench_rnd = torch.zeros(pow10:numel())
     local bench_srt = torch.zeros(pow10:numel())
@@ -11,7 +12,7 @@ function testSort()
 
     local function time_sort(x)
         local start = os.clock()
-        torch.sort(x)
+        torch.sort(x,descending)
         return (os.clock()-start)
     end
 
@@ -40,9 +41,10 @@ function testSort()
                  {'Sorted', pow10, bench_srt})
     gnuplot.xlabel('Log10(N)')
     gnuplot.ylabel('Time (s)')
-    gnuplot.figprint('timeSort.png')
+    gnuplot.figprint(output)
     print('RND:', bench_rnd)
     print('SRT:', bench_srt)
 end
 
-testSort()
+testSort('timeSortAscending.png', false) -- Ascending
+testSort('timeSortDescending.png', true) -- Descending

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -1,6 +1,5 @@
 -- Test torch sort, show it suffers from the problems of quicksort
 -- i.e. complexity O(N^2) in worst-case of sorted list
-require 'mathx'
 require 'gnuplot'
 
 function testSort(output, descending)

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -1,0 +1,48 @@
+-- Test torch sort, show it suffers from the problems of quicksort
+-- i.e. complexity O(N^2) in worst-case of sorted list
+require 'mathx'
+require 'gnuplot'
+
+function testSort()
+    local pow10 = torch.linspace(1,5,10)
+    local bench_rnd = torch.zeros(pow10:numel())
+    local bench_srt = torch.zeros(pow10:numel())
+    local nrep = 3
+
+    local function time_sort(x)
+        local start = os.clock()
+        torch.sort(x)
+        return (os.clock()-start)
+    end
+
+    for j = 1,nrep do
+        for i = 1,pow10:numel() do
+
+            local this_time
+            local n = 10^pow10[i]
+
+            -- on random
+            this_time = time_sort(torch.rand(n))
+            print('RND j:', j, 'for 10^', pow10[i], ' time: ', this_time)
+            bench_rnd[i] = bench_rnd[i] + this_time/nrep
+            collectgarbage()
+
+            -- on random
+            this_time = time_sort(torch.linspace(0,1,n))
+            print('SRT j:', j, 'for 10^', pow10[i], ' time: ', this_time)
+            bench_srt[i] = bench_srt[i] + this_time/nrep
+            collectgarbage()
+
+        end
+        io.flush()
+    end
+    gnuplot.plot({'Random', pow10, bench_rnd},
+                 {'Sorted', pow10, bench_srt})
+    gnuplot.xlabel('Log10(N)')
+    gnuplot.ylabel('Time (s)')
+    gnuplot.figprint('timeSort.png')
+    print('RND:', bench_rnd)
+    print('SRT:', bench_srt)
+end
+
+testSort()


### PR DESCRIPTION
Hi guys

The current torch.sort() is a quicksort whose worst-case is O(N^2) on already sorted arrays -- a setup that happens often in practice. This pull request done with @d11  speeds it up back to O(N log N), by using the common trick of changing the pivot to the middle element of the partition. This moves the worst-case to some very rare configurations.
We also add some unit tests to make sure sorting still works, and a little script to benchmark the running times.

Runtime comparison between sorting a random array and a sorted array, as a function of tensor size, before modification:
![timesortbefore](https://f.cloud.github.com/assets/660037/1345369/a680ddba-368e-11e3-8bfb-86baeebee188.png)

and after modification:
![timesort](https://f.cloud.github.com/assets/660037/1345397/25bde8ac-368f-11e3-88c4-7858d8e97e4f.png)
