### PR TITLE
Fixed PairwiseDifference for norms other than 1

### DIFF
--- a/extra/nn/PairwiseDistance.lua
+++ b/extra/nn/PairwiseDistance.lua
@@ -20,6 +20,10 @@ function PairwiseDistance:updateOutput(input)
       --local diff = torch.add(input[1], -1, input[2])
       diff:add(input[1], -1, input[2])
 
+      if math.mod(self.norm, 2) == 1 then
+         diff:abs()
+      end
+
       self.output:resize(input[1]:size(1))
       self.output:zero()
       self.output:add(diff:pow(self.norm):sum(2))

--- a/extra/nn/PairwiseDistance.lua
+++ b/extra/nn/PairwiseDistance.lua
@@ -6,28 +6,30 @@ function PairwiseDistance:__init(p)
    -- state
    self.gradInput = {torch.Tensor(), torch.Tensor()}
    self.output = torch.Tensor(1)
+   self.diff = torch.Tensor()
    self.norm=p
 end 
   
 function PairwiseDistance:updateOutput(input)
-   if input[1]:dim() == 1 then
-      self.output[1]=input[1]:dist(input[2],self.norm)
-   elseif input[1]:dim() == 2 then
-      self.diff = self.diff or input[1].new()
-      self.diff:resizeAs(input[1])
-
-      local diff = self.diff:zero()
-      --local diff = torch.add(input[1], -1, input[2])
-      diff:add(input[1], -1, input[2])
-      diff:abs()
-
-      self.output:resize(input[1]:size(1))
-      self.output:zero()
-      self.output:add(diff:pow(self.norm):sum(2))
-      self.output:pow(1./self.norm)
-   else
+   if input[1]:dim() > 2 then
       error('input must be vector or matrix')
    end
+   if input[1]:dim() == 1 then
+     -- Reshape the input so it always looks like a batch (avoids multiple
+     -- code-paths).  (Clement's good suggestion)
+     input[1]:resize(1,input[1]:size(1))
+     input[2]:resize(1,input[2]:size(1))
+   end
+ 
+   self.diff:resizeAs(input[1])
+   self.diff:zero()
+   self.diff:add(input[1], -1, input[2])
+   self.diff:abs()
+
+   self.output:resize(input[1]:size(1))
+   self.output:zero()
+   self.output:add(self.diff:pow(self.norm):sum(2))
+   self.output:pow(1./self.norm)
 
    return self.output
 end
@@ -38,46 +40,49 @@ local function mathsign(x)
 end
 
 function PairwiseDistance:updateGradInput(input, gradOutput)
+   if input[1]:dim() > 2 then
+      error('input must be vector or matrix')
+   end
+
+   if input[1]:dim() == 1 then
+     -- Reshape the input so it always looks like a batch (avoids multiple
+     -- code-paths).  (Clement's good suggestion)
+     input[1]:resize(1,input[1]:size(1))
+     input[2]:resize(1,input[2]:size(1))
+   end
+
    self.gradInput[1]:resize(input[1]:size()) 
    self.gradInput[2]:resize(input[2]:size()) 
    self.gradInput[1]:copy(input[1])
-   self.gradInput[1]:add(-1, input[2])
+   self.gradInput[1]:add(-1, input[2]) 
+   
    if self.norm==1 then
      self.gradInput[1]:apply(mathsign)
    else
-     -- See here for derivative of p-norm:
+     -- Note: derivative of p-norm:
      -- d/dx_k(||x||_p) = (x_k * abs(x_k)^(p-2)) / (||x||_p)^(p-1)
-     -- http://en.wikipedia.org/wiki/Norm_(mathematics)
-     self.gradInput[1]:cmul(self.gradInput[1]:clone():abs():pow(self.norm-2))
-     if input[1]:dim() == 1 then
-        -- Avoid the expand for dimension 1
-        self.gradInput[1]:mul(math.pow(self.output[1],-(self.norm-1)))
-     elseif input[1]:dim() == 2 then
-        -- This is a little messy...  But it does work
-        self.outExpand = self.outExpand or self.output.new()
-        self.outExpand:resize(self.output:size(1), 1)
-        self.outExpand:copy(self.output)
-        self.outExpand:pow(-(self.norm-1))
-        self.gradInput[1]:cmul(self.outExpand:expand(self.gradInput[1]:size(1),
-           self.gradInput[1]:size(2)))
-     else
-        error('input must be vector or matrix')
+     if (self.norm > 2) then
+        self.gradInput[1]:cmul(self.gradInput[1]:clone():abs():pow(self.norm-2))
      end
-   end
-   if input[1]:dim() == 1 then
-      self.gradInput[1]:mul(gradOutput[1])
-   elseif input[1]:dim() == 2 then
-      self.grad = self.grad or gradOutput.new()
-      self.ones = self.ones or gradOutput.new()
 
-      self.grad:resizeAs(input[1]):zero()
-      self.ones:resize(input[1]:size(2)):fill(1)
-
-      self.grad:addr(gradOutput, self.ones)
-      self.gradInput[1]:cmul(self.grad)
-   else
-      error('input must be vector or matrix')
+     self.outExpand = self.outExpand or self.output.new()
+     self.outExpand:resize(self.output:size(1), 1)
+     self.outExpand:copy(self.output)
+     self.outExpand:add(1.0e-6)  -- Prevent divide by zero errors
+     self.outExpand:pow(-(self.norm-1))
+     self.gradInput[1]:cmul(self.outExpand:expand(self.gradInput[1]:size(1),
+        self.gradInput[1]:size(2)))
    end
+   
+   self.grad = self.grad or gradOutput.new()
+   self.ones = self.ones or gradOutput.new()
+
+   self.grad:resizeAs(input[1]):zero()
+   self.ones:resize(input[1]:size(2)):fill(1)
+
+   self.grad:addr(gradOutput, self.ones)
+   self.gradInput[1]:cmul(self.grad)
+   
    self.gradInput[2]:zero():add(-1, self.gradInput[1])
    return self.gradInput
 end

--- a/extra/nn/PairwiseDistance.lua
+++ b/extra/nn/PairwiseDistance.lua
@@ -48,7 +48,7 @@ function PairwiseDistance:updateGradInput(input, gradOutput)
      -- See here for derivative of p-norm:
      -- d/dx_k(||x||_p) = (x_k * abs(x_k)^(p-2)) / (||x||_p)^(p-1)
      -- http://en.wikipedia.org/wiki/Norm_(mathematics)
-     self.gradInput[1]:cmul(torch.abs(self.gradInput[1]):pow(self.norm-2))
+     self.gradInput[1]:cmul(self.gradInput[1]:clone():abs():pow(self.norm-2))
      if input[1]:dim() == 1 then
         -- Avoid the expand for dimension 1
         self.gradInput[1]:mul(math.pow(self.output[1],-(self.norm-1)))

--- a/extra/nn/PairwiseDistance.lua
+++ b/extra/nn/PairwiseDistance.lua
@@ -86,3 +86,18 @@ function PairwiseDistance:updateGradInput(input, gradOutput)
    self.gradInput[2]:zero():add(-1, self.gradInput[1])
    return self.gradInput
 end
+
+-- save away Module:type(type) for later use.
+PairwiseDistance._parent_type = parent.type
+
+-- Fix the bug where tmp = nn.PairwiseDistance:cuda() fails to convert table
+-- contents.  We could, and probably should, change Module.lua to loop over
+-- and convert all the table elements in a module, but that might have 
+-- repercussions, so this is a safer solution.
+function PairwiseDistance:type(type)
+   self:_parent_type(type)  -- Call the parent (Module) type function
+   -- Now convert the left over table elements
+   self.gradInput[1] = self.gradInput[1]:type(type)
+   self.gradInput[2] = self.gradInput[2]:type(type)
+end
+

--- a/extra/nn/test/test.lua
+++ b/extra/nn/test/test.lua
@@ -1530,6 +1530,59 @@ function nntest.Module_getParameters_7()
    mytester:asserteq(p:nElement(), 121, 'error: incorrect number of elements in flat vector')
 end
 
+function nntest.PairwiseDistance()
+   -- Note: testJacobian doesn't support table inputs, and rather than re-write
+   -- it so that it does, I'll just use a split table module on the input.
+   -- I assume both SplitTable and Sequential do not have bugs, otherwise this
+   -- test will break.
+   for p = 1,4 do  -- test a few Lp norms
+      -- TEST CASE 1: non-batch inputs
+      local ini = math.random(10,20)
+      local input = torch.Tensor(2, ini):zero()
+      local module = nn.Sequential()
+      module:add(nn.SplitTable(1))
+      module:add(nn.PairwiseDistance(p))
+
+      local err = jac.testJacobian(module,input)
+      mytester:assertlt(err,precision, ' error on state ')
+ 
+      local ferr,berr = jac.testIO(module,input)
+      mytester:asserteq(ferr, 0, torch.typename(module)..' - i/o forward err ')
+      mytester:asserteq(berr, 0, torch.typename(module)..' - i/o backward err ')
+
+      -- Also check that the forward prop result is correct
+      err = torch.dist(input:select(1,1), input:select(1,2), p) - 
+        module:forward(input)[1]
+      mytester:assertlt(err,precision, ' error on non-batch fprop ') 
+ 
+      -- TEST CASE 2: batch input
+      local inj = math.random(10,20)
+      input = torch.Tensor(2, inj, ini):zero()
+
+      -- (Rebuild the module to avoid correlated tests)
+      module = nn.Sequential()
+      module:add(nn.SplitTable(1))
+      module:add(nn.PairwiseDistance(p))
+
+      err = jac.testJacobian(module,input)
+      mytester:assertlt(err,precision, ' error on state ')
+
+      -- Also check that the forward prop result is correct
+      -- manually calculate each distance separately
+      local inputa = torch.rand(inj,ini)
+      local inputb = torch.rand(inj,ini)
+      local dist_manual = torch.Tensor(inj)
+      for i=1, inputa:size(1) do
+         dist_manual[i] = torch.dist(inputa:select(1,i), inputb:select(1,i),p) 
+      end
+      -- compare the distances to the module's fprop
+      local dist = module:forward(torch.cat(inputa,inputb,1):resize(2,inj,ini))
+      err = dist - dist_manual 
+      mytester:assertlt(err:norm(), precision, torch.typename(module) .. 
+         ' error on batch fprop ')
+  end
+end
+
 mytester:add(nntest)
 
 if not nn then

--- a/extra/nn/test/test.lua
+++ b/extra/nn/test/test.lua
@@ -1536,7 +1536,7 @@ function nntest.PairwiseDistance()
    -- I assume both SplitTable and Sequential do not have bugs, otherwise this
    -- test will break.
    for p = 1,4 do  -- test a few Lp norms
-      -- TEST CASE 1: non-batch inputs
+      -- TEST CASE 1: non-batch input, same code path but includes a resize
       local ini = math.random(10,20)
       local input = torch.Tensor(2, ini):zero()
       local module = nn.Sequential()
@@ -1550,7 +1550,8 @@ function nntest.PairwiseDistance()
       mytester:asserteq(ferr, 0, torch.typename(module)..' - i/o forward err ')
       mytester:asserteq(berr, 0, torch.typename(module)..' - i/o backward err ')
 
-      -- Also check that the forward prop result is correct
+      -- Also check that the forward prop result is correct.
+      input = torch.rand(2, ini)
       err = torch.dist(input:select(1,1), input:select(1,2), p) - 
         module:forward(input)[1]
       mytester:assertlt(err,precision, ' error on non-batch fprop ') 
@@ -1567,7 +1568,7 @@ function nntest.PairwiseDistance()
       err = jac.testJacobian(module,input)
       mytester:assertlt(err,precision, ' error on state ')
 
-      -- Also check that the forward prop result is correct
+      -- Also check that the forward prop result is correct.
       -- manually calculate each distance separately
       local inputa = torch.rand(inj,ini)
       local inputb = torch.rand(inj,ini)


### PR DESCRIPTION
OK, it turns out that the inputGrad was wrong before the batch support was added for norms other than 1...  The sign of the gradient was OK, but the magnitude was wrong.  I've fixed this but it REALLY needs review.  

Can you check that I'm using the expand function correctly (I don't think it allocates memory, but I'm not 100% sure)?

I also created "reasonably" comprehensive test for PairwiseDistance in /extra/nn/test/test.lua.  This also needs review.  The tests for fprop and bprop pass.
