### PR TITLE
Add new asserts to Tester

### DIFF
--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -45,9 +45,8 @@ end
 function Tester:assertalmosteq (a, b, condition, message)
    condition = condition or 1e-16
    local err = math.abs(a-b)
-   self:assert_sub(err < condition, string.format('%s\n%s  val=%s, condition=%s',message,' ALMST_EQ(==) violation ', tostring(val), tostring(condition)))
+   self:assert_sub(err < condition, string.format('%s\n%s  val=%s, condition=%s',message,' ALMOST_EQ(==) violation ', tostring(err), tostring(condition)))
 end
-
 
 function Tester:assertne (val, condition, message)
    self:assert_sub(val~=condition,string.format('%s\n%s  val=%s, condition=%s',message,' NE(~=) violation ', tostring(val), tostring(condition)))

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -42,6 +42,13 @@ function Tester:asserteq (val, condition, message)
    self:assert_sub(val==condition,string.format('%s\n%s  val=%s, condition=%s',message,' EQ(==) violation ', tostring(val), tostring(condition)))
 end
 
+function Tester:assertalmosteq (a, b, condition, message)
+   condition = condition or 1e-16
+   local err = math.abs(a-b)
+   self:assert_sub(err < condition, string.format('%s\n%s  val=%s, condition=%s',message,' ALMST_EQ(==) violation ', tostring(val), tostring(condition)))
+end
+
+
 function Tester:assertne (val, condition, message)
    self:assert_sub(val~=condition,string.format('%s\n%s  val=%s, condition=%s',message,' NE(~=) violation ', tostring(val), tostring(condition)))
 end

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -81,9 +81,20 @@ function Tester:assertTableNe(ta, tb, message)
 end
 
 function Tester:assertError(f, message)
-   status, err = pcall(f)
-   self:assert_sub(status == false, string.format('%s\n%s  condition=%s',message,' ERROR violation ', 'should have errored'))
+    return self:assertErrorObj(f, function(err) return true end, message)
 end
+
+function Tester:assertErrorMsg(f, errmsg, message)
+    return self:assertErrorObj(f, function(err) return err == errmsg end, message)
+end
+
+function Tester:assertErrorObj(f, errcomp, message)
+    -- errcomp must be  a function  that compares the error object to its expected value
+   local status, err = pcall(f)
+   self:assert_sub(status == false and errcomp(err), string.format('%s\n%s  condition=%s',message,' ERROR violation ', 'should have errored'))
+end
+
+
 
 function Tester:pcall(f)
    local nerr = #self.errors

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -88,6 +88,10 @@ function Tester:assertErrorMsg(f, errmsg, message)
     return self:assertErrorObj(f, function(err) return err == errmsg end, message)
 end
 
+function Tester:assertErrorPattern(f, errPattern, message)
+    return self:assertErrorObj(f, function(err) return string.find(err, errPattern) ~= nil end, message)
+end
+
 function Tester:assertErrorObj(f, errcomp, message)
     -- errcomp must be  a function  that compares the error object to its expected value
    local status, err = pcall(f)

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -102,7 +102,7 @@ end
 function Tester:assertErrorObj(f, errcomp, message)
     -- errcomp must be  a function  that compares the error object to its expected value
    local status, err = pcall(f)
-   self:assert_sub(status == false and errcomp(err), string.format('%s\n%s  condition=%s',message,' ERROR violation ', 'did not match expected error'))
+   self:assert_sub(status == false and errcomp(err), string.format('%s\n%s  err=%s', message,' ERROR violation ', tostring(err)))
 end
 
 

--- a/pkg/torch/Tester.lua
+++ b/pkg/torch/Tester.lua
@@ -95,7 +95,7 @@ end
 function Tester:assertErrorObj(f, errcomp, message)
     -- errcomp must be  a function  that compares the error object to its expected value
    local status, err = pcall(f)
-   self:assert_sub(status == false and errcomp(err), string.format('%s\n%s  condition=%s',message,' ERROR violation ', 'should have errored'))
+   self:assert_sub(status == false and errcomp(err), string.format('%s\n%s  condition=%s',message,' ERROR violation ', 'did not match expected error'))
 end
 
 

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -454,10 +454,6 @@ function torchtest.BugInAssertTableEq()
    mytester:assertTableEq(t, tt, 'assertTableEq: not deemed equal')
    mytester:assertTableNe(t, {3,2,1}, 'assertTableNe: not deemed different')
    mytester:assertTableEq({1,2,{4,5}}, {1,2,{4,5}}, 'assertTableEq: fails on recursive lists')
-   -- TODO: once a mechanism for testing that assert fails exist, test that the two asserts below do not pass
-   -- should not pass: mytester:assertTableEq(t, {1,2}, 'assertTableNe: different size should not be equal') 
-   -- should not pass: mytester:assertTableEq(t, {1,2,3,4}, 'assertTableNe: different size should not be equal')
-
    mytester:assertTableNe(t, {1,2}, 'assertTableNe: different size not deemed different')
    mytester:assertTableNe(t, {1,2,3,4}, 'assertTableNe: different size not deemed different')
 end

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -442,6 +442,7 @@ function torchtest.TestAsserts()
    local xx = x:clone();
    mytester:assertTensorEq(x, xx, 1e-16, 'assertTensorEq: not deemed equal')
    mytester:assertTensorNe(x, xx+1, 1e-16, 'assertTensorNe: not deemed different')
+   mytester:assertalmosteq(0, 1e-250, 1e-16, 'assertalmosteq: not deemed different')
 end
 
 

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -437,6 +437,8 @@ end
 
 function torchtest.TestAsserts()
    mytester:assertError(function() error('hello') end, 'assertError: Error not caught')
+   mytester:assertErrorMsg(function() error('hello') end, 'test.lua:440: hello', 'assertError: "hello" Error not caught')
+   mytester:assertErrorPattern(function() error('hello') end, '.*ll.*', 'assertError: ".*ll.*" Error not caught')
 
    local x = torch.rand(100,100)*2-1;
    local xx = x:clone();


### PR DESCRIPTION
- `assertErrorMsg()` to compare the returned error message to a specific string
- `assertErrorPattern()` to check against a pattern
- `assertErrorObj()` for arbitrary comparison function to arbitrary error objects (useful if returning stack trace, for example)
- `assertalmostequal()` to compare numbers in floating point precision, similar to `assertTensorEq()`
- clarify the error messages sent by failed `assertError()`
