### PR TITLE
Fix quicksort on constant arrays

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -923,7 +923,8 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
    This public-domain C implementation by Darel Rex Finley.
    Thanks man :)
 
-    Updated Oct 16 2013: change choice of pivot to avoid worst-case being a pre-sorted input
+    Updated Oct 16 2013: change choice of pivot to avoid worst-case being a pre-sorted input - Daniel and Julien
+    Updated Oct 24 2013: change pivot comparison to strict inequality to avoid worst-case on constant input - Julien
 */
 #define  MAX_LEVELS  300
 static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long stride)
@@ -945,14 +946,14 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
       arr[P*stride]=rswap;
       idx[P*stride]=swap;
       while (L<R) {
-        while (arr[R*stride]>=piv && L<R)
+        while (arr[R*stride]>piv && L<R)
             R--;
         if (L<R) {
             idx[L*stride]=idx[R*stride];
             arr[L*stride]=arr[R*stride];
             L++;
         }
-        while (arr[L*stride]<=piv && L<R)
+        while (arr[L*stride]<piv && L<R)
             L++;
         if (L<R) {
             idx[R*stride]=idx[L*stride];
@@ -995,14 +996,14 @@ static void THTensor_(quicksortdescend)(real *arr, long *idx, long elements, lon
       arr[P*stride]=rswap;
       idx[P*stride]=swap;
       while (L<R) {
-        while (arr[R*stride]<=piv && L<R)
+        while (arr[R*stride]<piv && L<R)
             R--;
         if (L<R) {
             idx[L*stride]=idx[R*stride];
             arr[L*stride]=arr[R*stride];
             L++;
         }
-        while (arr[L*stride]>=piv && L<R)
+        while (arr[L*stride]>piv && L<R)
             L++;
         if (L<R) {
             idx[R*stride]=idx[L*stride];

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -924,7 +924,7 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
    Thanks man :)
 
     Updated Oct 16 2013: change choice of pivot to avoid worst-case being a pre-sorted input - Daniel and Julien
-    Updated Oct 24 2013: change pivot comparison to strict inequality to avoid worst-case on constant input - Julien
+    Updated Oct 24 2013: change pivot comparison to strict inequality to avoid worst-case on constant input, see Sedgewick, Algorithms in C, Addison Wesley, 1990, p. 120 - Julien
 */
 #define  MAX_LEVELS  300
 static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long stride)

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -161,6 +161,27 @@ function torchtest.sortAscending()
            1e-16,
            "torch.sort (ascending) simple sort"
        )
+   -- Test that we still have proper sorting with duplicate keys
+   local x = torch.floor(torch.rand(msize,msize)*10)
+   torch.sort(mxx,ixx,x)
+   local increasing = true
+   for j = 1,msize do
+       for k = 2,msize do
+           increasing = increasing and (mxx[j][k-1] <= mxx[j][k])
+       end
+   end
+   mytester:assert(increasing, 'torch.sort (ascending) increasing with equal keys')
+   local seen = torch.ByteTensor(msize)
+   local indicesCorrect = true
+   for k = 1,msize do
+       seen:zero()
+       for j = 1,msize do
+           indicesCorrect = indicesCorrect and (x[k][ixx[k][j]] == mxx[k][j])
+           seen[ixx[k][j]] = 1
+       end
+       indicesCorrect = indicesCorrect and (torch.sum(seen) == msize)
+   end
+   mytester:assert(indicesCorrect, 'torch.sort (ascending) indices with equal keys')
 end
 function torchtest.sortDescending()
    local x = torch.rand(msize,msize)
@@ -170,13 +191,13 @@ function torchtest.sortDescending()
    torch.sort(mxx,ixx,x,true)
    mytester:asserteq(maxdiff(mx,mxx),0,'torch.sort (descending) value')
    mytester:asserteq(maxdiff(ix,ixx),0,'torch.sort (descending) index')
-   local increasing = true
+   local decreasing = true
    for j = 1,msize do
        for k = 2,msize do
-           increasing = increasing and (mxx[j][k-1] > mxx[j][k])
+           decreasing = decreasing and (mxx[j][k-1] > mxx[j][k])
        end
    end
-   mytester:assert(increasing, 'torch.sort (descending) decreasing')
+   mytester:assert(decreasing, 'torch.sort (descending) decreasing')
    local seen = torch.ByteTensor(msize)
    local indicesCorrect = true
    for k = 1,msize do
@@ -194,6 +215,27 @@ function torchtest.sortDescending()
            1e-16,
            "torch.sort (descending) simple sort"
        )
+   -- Test that we still have proper sorting with duplicate keys
+   local x = torch.floor(torch.rand(msize,msize)*10)
+   torch.sort(mxx,ixx,x,true)
+   local decreasing = true
+   for j = 1,msize do
+       for k = 2,msize do
+           decreasing = decreasing and (mxx[j][k-1] >= mxx[j][k])
+       end
+   end
+   mytester:assert(decreasing, 'torch.sort (descending) decreasing with equal keys')
+   local seen = torch.ByteTensor(msize)
+   local indicesCorrect = true
+   for k = 1,msize do
+       seen:zero()
+       for j = 1,msize do
+           indicesCorrect = indicesCorrect and (x[k][ixx[k][j]] == mxx[k][j])
+           seen[ixx[k][j]] = 1
+       end
+       indicesCorrect = indicesCorrect and (torch.sum(seen) == msize)
+   end
+   mytester:assert(indicesCorrect, 'torch.sort (descending) indices with equal keys')
 end
 function torchtest.tril()
    local x = torch.rand(msize,msize)

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -7,6 +7,7 @@ function testSort(output, descending)
     local pow10 = torch.linspace(1,5,10)
     local bench_rnd = torch.zeros(pow10:numel())
     local bench_srt = torch.zeros(pow10:numel())
+    local bench_cst = torch.zeros(pow10:numel())
     local nrep = 3
 
     local function time_sort(x)
@@ -27,22 +28,30 @@ function testSort(output, descending)
             bench_rnd[i] = bench_rnd[i] + this_time/nrep
             collectgarbage()
 
-            -- on random
+            -- on sorted
             this_time = time_sort(torch.linspace(0,1,n))
             print('SRT j:', j, 'for 10^', pow10[i], ' time: ', this_time)
             bench_srt[i] = bench_srt[i] + this_time/nrep
+            collectgarbage()
+
+            -- on constant
+            this_time = time_sort(torch.zeros(n))
+            print('CST j:', j, 'for 10^', pow10[i], ' time: ', this_time)
+            bench_cst[i] = bench_cst[i] + this_time/nrep
             collectgarbage()
 
         end
         io.flush()
     end
     gnuplot.plot({'Random', pow10, bench_rnd},
-                 {'Sorted', pow10, bench_srt})
+                 {'Sorted', pow10, bench_srt},
+                 {'Constant', pow10, bench_cst})
     gnuplot.xlabel('Log10(N)')
     gnuplot.ylabel('Time (s)')
     gnuplot.figprint(output)
     print('RND:', bench_rnd)
     print('SRT:', bench_srt)
+    print('CST:', bench_cst)
 end
 
 testSort('timeSortAscending.png', false) -- Ascending


### PR DESCRIPTION
TL;DR: This pull-request fixes the slow time in sorting arrays with all elements being equal.

Long version:
As pointed by Tom in https://github.com/torch/torch7-distro/pull/176#issuecomment-26993416 , `torch.sort()` is extremely slow on arrays with long stretches of constant numbers.

This was due to the original quicksort implementation using a 'or-equal' inequality when comparing elements with the pivot during the partitioning. That was not a good idea: while both Wikipedia and Cormen et al's "Introduction to Algorithms" use a lower-or-equal comparison when partitioning, Sedgewick's Algorithms in C (first edition, 1990) discusses p. 120 quicksort for arrays with duplicated keys. It recommends to stop whenever you encounter an element equal to the pivot, so as to "balance-out" the partitions. See also his landmark article (which Cormen refers to): http://www.csie.ntu.edu.tw/~b93076/p847-sedgewick.pdf
Sedgewick did his whole PhD on Quicksort :)
And here's his whole paper on the topic of quicksort with equal keys.:
http://www.cs.auckland.ac.nz/~mcw/Teaching/refs/sorting/quicksort-equal-keys.pdf
In our case, this is salvation ;-)

I also added a tests on sorting with duplicate keys, which weren't checked until now.

Here are the timings before:
![timesortascending](https://f.cloud.github.com/assets/660037/1401051/8a788aa4-3ccf-11e3-8f67-040218229a2e.png)
and now:
![timesortascending](https://f.cloud.github.com/assets/660037/1401055/9285d77e-3ccf-11e3-829b-b67137569b94.png)
