### PR TITLE
Fix possible bug in potrf wrapping: return a triangular matrix

### DIFF
--- a/lib/TH/generic/THTensorLapack.c
+++ b/lib/TH/generic/THTensorLapack.c
@@ -518,13 +518,13 @@ TH_API void THTensor_(potrf)(THTensor *ra_, THTensor *a)
     THError("Lapack potrf : Argument %d : illegal value", -info);
   }
 
-  /* Build full matrix */
+  /* Build full upper-triangular matrix */
   {
     real *p = THTensor_(data)(ra__);
     long i,j;
     for (i=0; i<n; i++) {
       for (j=i+1; j<n; j++) {
-        p[i*n+j] = p[j*n+i];
+        p[i*n+j] = 0;
       }
     }
   }

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -477,8 +477,16 @@ function torchtest.testCholesky()
     local A = torch.mm(x, x:t())
     local C = torch.potrf(A)
     local B = torch.mm(C:t(), C)
-    mytester:assertTensorEq(A, B, 1e-15, 'potrf did not allow rebuilding the original matrix')
+    mytester:assertTensorEq(A, B, 1e-14, 'potrf did not allow rebuilding the original matrix')
 end
+function torchtest.testCholeskyErrsOnRankDeficient()
+    local x = torch.rand(5,5)
+    local A = torch.mm(x, x:t())
+    -- Make the matrix rank-defficient
+    A[{{},5}]:copy(A[{{},{1}}])
+    mytester:assertError(function() torch.potrf(A) end)
+end
+
 
 function torch.test()
    math.randomseed(os.time())

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -472,6 +472,14 @@ function torchtest.RNGState()
    mytester:assertTensorEq(before, after, 1e-16, 'getRNGState/setRNGState not generating same sequence')
 end
 
+function torchtest.testCholesky()
+    local x = torch.rand(10,10)
+    local A = torch.mm(x, x:t())
+    local C = torch.potrf(A)
+    local B = torch.mm(C:t(), C)
+    mytester:assertTensorEq(A, B, 1e-15, 'potrf did not allow rebuilding the original matrix')
+end
+
 function torch.test()
    math.randomseed(os.time())
    mytester = torch.Tester()


### PR DESCRIPTION
The cholesky decomposition is supposed to be upper triangular. The wrapper for
Lapack's `potrf`, instead, filled the resulting matrix to make it symmetric.I wonder 
if this was not a copy/paste overlook, since I do not see a reason to return a symmetric cholesky. 
Am I missing something?

This patch also adds a test that the result of cholesky decomposition actually factorizes a random
definite positive matrix.
