### PR TITLE
randn() not reset by manualSeed nor by set/getRNGState

### DIFF
--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -102,6 +102,8 @@ void THRandom_manualSeed(unsigned long the_seed_)
   }
   left = 1;
   initf = 1;
+  /* Added for the normal distribution */
+  normal_is_valid = 0;
 }
 
 unsigned long THRandom_initialSeed()

--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -240,7 +240,7 @@ int THRandom_bernoulli(double p)
 }
 
 /* returns the random number state */
-void THRandom_getState(unsigned long *_state, long *offset, long *_left)
+void THRandom_getMTState(unsigned long *_state, long *offset, long *_left)
 {
   if(initf == 0)
     THRandom_seed();
@@ -250,7 +250,7 @@ void THRandom_getState(unsigned long *_state, long *offset, long *_left)
 }
 
 /* sets the random number state */
-void THRandom_setState(unsigned long *_state, long offset, long _left)
+void THRandom_setMTState(unsigned long *_state, long offset, long _left)
 {
   memmove(state, _state, n*sizeof(long));
   next = state + offset;

--- a/lib/TH/THRandom.c
+++ b/lib/TH/THRandom.c
@@ -249,6 +249,15 @@ void THRandom_getMTState(unsigned long *_state, long *offset, long *_left)
   *_left = left;
 }
 
+void THRandom_getNormalState(int * _normal_is_valid, double * _normal_x, double *_normal_rho)
+{
+  if(initf == 0)
+      THError("You must call getMTState before getNormalState");
+  *_normal_is_valid = normal_is_valid;
+  *_normal_x        = normal_x;
+  *_normal_rho      = normal_rho;
+}
+
 /* sets the random number state */
 void THRandom_setMTState(unsigned long *_state, long offset, long _left)
 {
@@ -256,4 +265,10 @@ void THRandom_setMTState(unsigned long *_state, long offset, long _left)
   next = state + offset;
   left = _left;
   initf = 1;
+}
+void THRandom_setNormalState(int _normal_is_valid, double _normal_x, double _normal_rho) 
+{
+  normal_is_valid = _normal_is_valid;
+  normal_x        = _normal_x;
+  normal_rho      = _normal_rho;
 }

--- a/lib/TH/THRandom.h
+++ b/lib/TH/THRandom.h
@@ -50,8 +50,8 @@ TH_API int THRandom_geometric(double p);
 TH_API int THRandom_bernoulli(double p);
 
 /* returns the random number state */
-TH_API void THRandom_getState(unsigned long *state, long *offset, long *_left);
+TH_API void THRandom_getMTState(unsigned long *state, long *offset, long *_left);
 
 /* sets the random number state */
-TH_API void THRandom_setState(unsigned long *state, long offset, long _left);
+TH_API void THRandom_setMTState(unsigned long *state, long offset, long _left);
 #endif

--- a/lib/TH/THRandom.h
+++ b/lib/TH/THRandom.h
@@ -51,7 +51,9 @@ TH_API int THRandom_bernoulli(double p);
 
 /* returns the random number state */
 TH_API void THRandom_getMTState(unsigned long *state, long *offset, long *_left);
+TH_API void THRandom_getNormalState(int * _normal_is_valid, double * _normal_x, double *_normal_rho);
 
 /* sets the random number state */
 TH_API void THRandom_setMTState(unsigned long *state, long offset, long _left);
+TH_API void THRandom_setNormalState(int _normal_is_valid, double _normal_x, double _normal_rho);
 #endif

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -59,7 +59,41 @@ TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv)
 {
   TH_TENSOR_APPLY(real, self, *self_data = (real)THRandom_logNormal(mean, stdv););
 }
+#endif
 
+#if defined(TH_REAL_IS_DOUBLE)
+TH_API void THTensor_(getNormalState)(THTensor *self)
+{
+  int normal_is_valid;
+  double * data;
+  double * normal_x;
+  double * normal_rho;
+
+  THTensor_(resize1d)(self,3);
+  data = (double *)THTensor_(data)(self);
+  normal_x = data+1;
+  normal_rho = data+2;
+
+  THRandom_getNormalState(&normal_is_valid, normal_x, normal_rho);
+  *data = (double)normal_is_valid;
+}
+
+TH_API void THTensor_(setNormalState)(THTensor *self)
+{
+  int normal_is_valid;
+  double * data;
+  double normal_x;
+  double normal_rho;
+
+
+  THArgCheck(THTensor_(nElement)(self) == 3, 1, "state should have 3 elements");
+  data = (double *)THTensor_(data)(self);
+  normal_is_valid = (int)data[0];
+  normal_x = data[1];
+  normal_rho = data[2];
+
+  THRandom_setNormalState(normal_is_valid, normal_x, normal_rho);
+}
 #endif
 
 #if defined(TH_REAL_IS_LONG)

--- a/lib/TH/generic/THTensorRandom.c
+++ b/lib/TH/generic/THTensorRandom.c
@@ -63,7 +63,7 @@ TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv)
 #endif
 
 #if defined(TH_REAL_IS_LONG)
-TH_API void THTensor_(getRNGState)(THTensor *self)
+TH_API void THTensor_(getMTState)(THTensor *self)
 {
   unsigned long *data;
   long *offset;
@@ -74,10 +74,10 @@ TH_API void THTensor_(getRNGState)(THTensor *self)
   offset = (long *)data+624;
   left = (long *)data+625;
 
-  THRandom_getState(data,offset,left);
+  THRandom_getMTState(data,offset,left);
 }
 
-TH_API void THTensor_(setRNGState)(THTensor *self)
+TH_API void THTensor_(setMTState)(THTensor *self)
 {
   unsigned long *data;
   long *offset;
@@ -88,7 +88,7 @@ TH_API void THTensor_(setRNGState)(THTensor *self)
   offset = (long *)(data+624);
   left = (long *)(data+625);
 
-  THRandom_setState(data,*offset,*left);
+  THRandom_setMTState(data,*offset,*left);
 }
 
 #endif

--- a/lib/TH/generic/THTensorRandom.h
+++ b/lib/TH/generic/THTensorRandom.h
@@ -15,8 +15,8 @@ TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv);
 #endif
 
 #if defined(TH_REAL_IS_LONG)
-TH_API void THTensor_(getRNGState)(THTensor *self);
-TH_API void THTensor_(setRNGState)(THTensor *self);
+TH_API void THTensor_(getMTState)(THTensor *self);
+TH_API void THTensor_(setMTState)(THTensor *self);
 #endif
 
 #endif

--- a/lib/TH/generic/THTensorRandom.h
+++ b/lib/TH/generic/THTensorRandom.h
@@ -14,6 +14,11 @@ TH_API void THTensor_(cauchy)(THTensor *self, double median, double sigma);
 TH_API void THTensor_(logNormal)(THTensor *self, double mean, double stdv);
 #endif
 
+#if defined(TH_REAL_IS_DOUBLE)
+TH_API void THTensor_(getNormalState)(THTensor *self);
+TH_API void THTensor_(setNormalState)(THTensor *self);
+#endif
+
 #if defined(TH_REAL_IS_LONG)
 TH_API void THTensor_(getMTState)(THTensor *self);
 TH_API void THTensor_(setMTState)(THTensor *self);

--- a/pkg/torch/CMakeLists.txt
+++ b/pkg/torch/CMakeLists.txt
@@ -3,7 +3,7 @@ IF("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUA
 ENDIF()
 
 SET(src DiskFile.c File.c MemoryFile.c PipeFile.c Storage.c Tensor.c Timer.c utils.c init.c TensorOperator.c TensorMath.c random.c)
-SET(luasrc init.lua File.lua Tensor.lua CmdLine.lua Tester.lua test/test.lua)
+SET(luasrc init.lua File.lua Tensor.lua CmdLine.lua Tester.lua randomState.lua test/test.lua)
 
 # Necessary do generate wrapper
 ADD_TORCH_WRAP(tensormathwrap TensorMath.lua)

--- a/pkg/torch/init.lua
+++ b/pkg/torch/init.lua
@@ -76,5 +76,6 @@ include('File.lua')
 include('CmdLine.lua')
 include('Tester.lua')
 include('test.lua')
+include('randomState.lua')
 
 return torch

--- a/pkg/torch/random.lua
+++ b/pkg/torch/random.lua
@@ -18,6 +18,9 @@ interface:wrap('manualSeed',
 
 interface:wrap('getMTState','THLongTensor_getMTState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
 interface:wrap('setMTState','THLongTensor_setMTState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
+interface:wrap('getNormalState','THDoubleTensor_getNormalState',{{name='DoubleTensor',default=true,returned=true,method={default='nil'}}})
+interface:wrap('setNormalState','THDoubleTensor_setNormalState',{{name='DoubleTensor',default=true,returned=true,method={default='nil'}}})
+
 
 interface:register("random__")
                 

--- a/pkg/torch/random.lua
+++ b/pkg/torch/random.lua
@@ -16,8 +16,8 @@ interface:wrap('manualSeed',
                'THRandom_manualSeed',
                {{name="long"}})
 
-interface:wrap('getRNGState','THLongTensor_getRNGState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
-interface:wrap('setRNGState','THLongTensor_setRNGState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
+interface:wrap('getMTState','THLongTensor_getMTState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
+interface:wrap('setMTState','THLongTensor_setMTState',{{name='LongTensor',default=true,returned=true,method={default='nil'}}})
 
 interface:register("random__")
                 

--- a/pkg/torch/randomState.lua
+++ b/pkg/torch/randomState.lua
@@ -1,7 +1,11 @@
 function torch.getRNGState()
-    return torch.getMTState()
+    return {
+        mt = torch.getMTState(),
+        normal = torch.getNormalState()
+    }
 end
 
 function torch.setRNGState(state)
-    return torch.setMTState(state)
+    torch.setMTState(state.mt)
+    torch.setNormalState(state.normal)
 end

--- a/pkg/torch/randomState.lua
+++ b/pkg/torch/randomState.lua
@@ -1,0 +1,7 @@
+function torch.getRNGState()
+    return torch.getMTState()
+end
+
+function torch.setRNGState(state)
+    return torch.setMTState(state)
+end

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -503,10 +503,13 @@ end
 function torchtest.RNGState()
    local ignored = torch.rand(1000)
    local state = torch.getRNGState()
-   local stateCloned = state:clone()
-   local before = torch.rand(1000)
+   local stateCloned = {
+       mt = state.mt:clone(),
+       normal = state.normal:clone()
+   }
 
-   mytester:assert(state:ne(stateCloned):long():sum() == 0, 'RNG (supposedly cloned) state has changed after random number generation')
+   local before = torch.rand(1000)
+   mytester:assert(state.mt:ne(stateCloned.mt):long():sum() == 0, 'RNG MT (supposedly cloned) state has changed after random number generation')
 
    torch.setRNGState(state)
    local after = torch.rand(1000)
@@ -518,7 +521,11 @@ function torchtest.RNGStateGauss()
    local before, after
 
    local state = torch.getRNGState()
-   local stateCloned = state:clone()
+   local stateCloned = {
+       mt = state.mt:clone(),
+       normal = state.normal:clone()
+   }
+
    before = torch.randn(1)
 
    torch.setRNGState(stateCloned)

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -513,6 +513,34 @@ function torchtest.RNGState()
    mytester:assertTensorEq(before, after, 1e-16, 'getRNGState/setRNGState not generating same sequence')
 end
 
+function torchtest.RNGStateGauss()
+   -- Test for issue #191
+   local before, after
+
+   local state = torch.getRNGState()
+   before = torch.randn(1)
+
+   torch.setRNGState(state)
+   after = torch.randn(1)
+
+   mytester:assertTensorEq(before, after, 1e-16, 'getRNGState/setRNGState not generating same odd gaussian sequence')
+end
+
+function torchtest.manualSeedGauss()
+   -- Test for issue #191
+   local before, after
+
+   torch.manualSeed(1234567890)
+   before = torch.randn(1)
+
+   torch.manualSeed(1234567890)
+   after = torch.randn(1)
+
+   mytester:assertTensorEq(before, after, 1e-16, 'manualSeed not generating same odd gaussian sequence')
+end
+
+
+
 function torchtest.testCholesky()
     local x = torch.rand(10,10)
     local A = torch.mm(x, x:t())

--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -518,9 +518,10 @@ function torchtest.RNGStateGauss()
    local before, after
 
    local state = torch.getRNGState()
+   local stateCloned = state:clone()
    before = torch.randn(1)
 
-   torch.setRNGState(state)
+   torch.setRNGState(stateCloned)
    after = torch.randn(1)
 
    mytester:assertTensorEq(before, after, 1e-16, 'getRNGState/setRNGState not generating same odd gaussian sequence')


### PR DESCRIPTION
As spotted by @schaul, and mentioned to @koraykv, the seed and state of the RNG do not reset properly when an odd number of gaussian has been generated:

```
[julien@stmartin Research]$ torch
Try the IDE: torch -ide
Type help() for more info
Torch 7.0  Copyright (C) 2001-2011 Idiap, NEC Labs, NYU
Lua 5.1  Copyright (C) 1994-2008 Lua.org, PUC-Rio
t7> torch.manualSeed(31); print(torch.randn(3))
-0.0545
 0.2364
 0.8518
[torch.DoubleTensor of dimension 3]

t7> torch.manualSeed(31); print(torch.randn(3))
-0.2295
-0.0545
 0.2364
[torch.DoubleTensor of dimension 3]

t7> torch.manualSeed(31); print(torch.randn(3))
-0.0545
 0.2364
 0.8518
[torch.DoubleTensor of dimension 3]
```

This is due to the global variables `int normal_is_valid` , `double normal_x`, `double normal_y`, and `double normal_rho` lines 17-20 of `THRandom.c` , which are ignored by `getRNGState`, `setRNGState`, and `manualSeed`.
