### PR TITLE
Remove unit test that required hard-coded line number

### DIFF
--- a/pkg/torch/test/test.lua
+++ b/pkg/torch/test/test.lua
@@ -479,7 +479,6 @@ end
 
 function torchtest.TestAsserts()
    mytester:assertError(function() error('hello') end, 'assertError: Error not caught')
-   mytester:assertErrorMsg(function() error('hello') end, 'test.lua:440: hello', 'assertError: "hello" Error not caught')
    mytester:assertErrorPattern(function() error('hello') end, '.*ll.*', 'assertError: ".*ll.*" Error not caught')
 
    local x = torch.rand(100,100)*2-1;


### PR DESCRIPTION
Sorry about that, it was a pain to change the line number every time test.lua
changed, removing the unit test.
