### PR TITLE
added 3 fields to cutorch.getDeviceProperties.

### DIFF
--- a/extra/cuda/pkg/cutorch/init.c
+++ b/extra/cuda/pkg/cutorch/init.c
@@ -70,6 +70,9 @@ static int cutorch_getDeviceProperties(lua_State *L)
   SET_DEVN_PROP(totalConstMem);
   SET_DEVN_PROP(totalGlobalMem);
   SET_DEVN_PROP(warpSize);
+  SET_DEVN_PROP(pciBusID);
+  SET_DEVN_PROP(pciDeviceID);
+  SET_DEVN_PROP(pciDomainID);
 
   lua_pushstring(L, prop.name);
   lua_setfield(L, -2, "name");


### PR DESCRIPTION
## Short explanation: 

Added more info to cutorch.getDeviceProperties() return table.  This is reasonably simple and innocuous request I think.
## Long explanation: 

I am putting together a mechanism to automatically select the GPU which is not being used from lua.  However, nvidia-smi uses NMVL to enumerate devices, while torch (correctly) uses the CUDA API.  The id of devices in NMVL is not guaranteed to be the same as those from CUDA (thanks to Soumith for finding this):

"The order in which NVML enumerates devices has no guarantees of consistency between reboots. For that reason it is recommended that devices be looked up by their PCI ids or board serial numbers"

Consequently, I've found on my machine that device 0 in nvidia-smi is device 2 in torch, while device 1 in nvidia-smi is device 1 in torch.  However, this re-ordering is not always consistent and on some reboots, nvidia-smi ids change.

Therefore, the only way to know for sure which device is which is by the pciBusID, which is why I am adding it to getDeviceProperties() return value.  I'm adding this pull request in case other people will also need this information for something similar in the future.
