### PR TITLE
Better qsort implementation from reference article

### DIFF
--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #ifndef TH_GENERIC_FILE
 #define TH_GENERIC_FILE "generic/THTensorMath.c"
 #else
@@ -919,6 +920,122 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
 }
 
 /* I cut and pasted (slightly adapted) the quicksort code from
+   Sedgewick's 1978 "Implementing Quicksort Programs" article
+   http://www.csie.ntu.edu.tw/~b93076/p847-sedgewick.pdf
+
+   It is the state of the art existing implementation. The macros 
+   are here to make as close a match as possible to the pseudocode of
+   Program 2 p.851
+
+   Note that other partition schemes exist, and are typically presented
+   in textbook, but those are less efficient. See e.g.
+   http://cs.stackexchange.com/questions/11458/quicksort-partitioning-hoare-vs-lomuto
+
+   Julien, November 12th 2013
+*/
+#define MAX_LEVELS  300
+#define M_SMALL 10 /* Limit for small subfiles */
+
+#define ARR(III) arr[(III)*stride]
+#define IDX(III) idx[(III)*stride]
+
+#define LONG_SWAP(AAA, BBB) swap = AAA; AAA = BBB; BBB = swap
+#define REAL_SWAP(AAA, BBB) rswap = AAA; AAA = BBB; BBB = rswap
+
+#define BOTH_SWAP(III, JJJ) \
+  REAL_SWAP(ARR(III), ARR(JJJ)); \
+  LONG_SWAP(IDX(III), IDX(JJJ))
+
+static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long stride)
+{
+  long beg[MAX_LEVELS], end[MAX_LEVELS], i, j, L, R, P, swap, pid, stack = 0, sz_right, sz_left;
+  real rswap, piv;
+  unsigned char done = 0;
+
+  /* beg[0]=0; end[0]=elements; */
+  stack = 0;
+  L = 0; R = elements-1;
+  done = elements-1 <= M_SMALL;
+
+  while(!done) {
+      /* Use median of three for pivot choice */
+      P=(L+R)>>1;
+      BOTH_SWAP(P, L+1);
+      if (ARR(L+1) > ARR(R)) { BOTH_SWAP(L+1, R); }
+      if (ARR(L) > ARR(R)) { BOTH_SWAP(L, R); }
+      if (ARR(L+1) > ARR(L)) { BOTH_SWAP(L+1, L); }
+
+      i = L+1; j = R; piv = ARR(L); pid = IDX(L);
+
+      do {
+          do { i = i+1; } while(ARR(i) < piv);
+          do { j = j-1; } while(ARR(j) > piv);
+          if (j < i)
+              break;
+          BOTH_SWAP(i, j);
+      } while(1);
+      BOTH_SWAP(L, j);
+      /* Left subfile is (L, j-1) */
+      /* Right subfile is (i, R) */
+      sz_left = j-L;
+      sz_right = R-i+1;
+      if (sz_left <= M_SMALL && sz_right <= M_SMALL) {
+          /* both subfiles are small */
+          /* if stack empty */
+          if (stack == 0) {
+              done = 1;
+          } else {
+              stack--;
+              L = beg[stack];
+              R = end[stack];
+          }
+      } else if (sz_left <= M_SMALL || sz_right <= M_SMALL) {
+              /* exactly one of the subfiles is small */
+              /* (L,R) = large subfile */
+              if (sz_left > sz_right) {
+                  /* Implicit: L = L; */
+                  R = j-1;
+              } else {
+                  L = i;
+                  /* Implicit: R = R; */
+              }
+      } else {
+          /* none of the subfiles is small */
+          /* push large subfile */
+          /* (L,R) = small subfile */
+          if (sz_left > sz_right) {
+              beg[stack] = L;
+              end[stack] = j-1;
+              stack++;
+              L = i;
+              /* Implicit: R = R */
+          } else {
+              beg[stack] = i;
+              end[stack] = R;
+              stack++;
+              /* Implicit: L = L; */
+              R = j-1;
+          }
+      }
+  } /* while not done */
+  /* Now insertion sort on the concatenation of subfiles */
+  for(i=elements-2; i>=0; i--) {
+    if (ARR(i) > ARR(i+1)) {
+          piv = ARR(i);
+      pid = IDX(i);
+      j = i+1;
+      do {
+          ARR(j-1) = ARR(j);
+          IDX(j-1) = IDX(j);
+          j = j+1;
+      } while(j < elements && ARR(j) < piv);
+      ARR(j-1) = piv;
+      IDX(j-1) = pid;
+     }
+  }
+}
+
+/* I cut and pasted (slightly adapted) the quicksort code from
    http://www.alienryderflex.com/quicksort/
    This public-domain C implementation by Darel Rex Finley.
    Thanks man :)
@@ -926,68 +1043,6 @@ void THTensor_(reshape)(THTensor *r_, THTensor *t, THLongStorage *size)
     Updated Oct 16 2013: change choice of pivot to avoid worst-case being a pre-sorted input - Daniel and Julien
     Updated Oct 24 2013: change pivot comparison to strict inequality to avoid worst-case on constant input, see Sedgewick, Algorithms in C, Addison Wesley, 1990, p. 120 - Julien
 */
-#define  MAX_LEVELS  300
-static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long stride)
-{
-  long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;
-  real rswap, piv;
-
-#define ARR(I) arr[(I)*stride]
-#define IDX(I) idx[(I)*stride]
-
-#define LONG_SWAP(A, B) swap = A; A = B; B = swap
-#define REAL_SWAP(A, B) rswap = A; A = B; B = rswap
-
-#define BOTH_SWAP(I, J) \
-  REAL_SWAP(ARR(I), ARR(J)); \
-  LONG_SWAP(IDX(I), IDX(J))
-
-  beg[0]=0; end[0]=elements;
-  while (i>=0) {
-    L=beg[i]; R=end[i]-1;
-    if (L<R) {
-      /* Use median of three for pivot choice */
-      P=(L+R)>>1;
-      BOTH_SWAP((L+R)>>1, L+1);
-      if (ARR(L+1) > ARR(R)) { BOTH_SWAP(L+1, R); }
-      if (ARR(L) > ARR(R)) { BOTH_SWAP(L, R); }
-      if (ARR(L+1) > ARR(L)) { BOTH_SWAP(L+1, L); }
-
-      piv=ARR(L);
-      pid=IDX(L);
-
-      while (L<R) {
-        while (ARR(R)>piv && L<R)
-            R--;
-        if (L<R) {
-            IDX(L)=IDX(R);
-            ARR(L)=ARR(R);
-            L++;
-        }
-        while (ARR(L)<piv && L<R)
-            L++;
-        if (L<R) {
-            IDX(R)=IDX(L);
-            ARR(R)=ARR(L);
-            R--;
-        }
-      }
-      IDX(L)=pid;
-      ARR(L)=piv;
-      beg[i+1]=L+1;
-      end[i+1]=end[i];
-      end[i++]=L;
-      if (end[i]-beg[i]>end[i-1]-beg[i-1]) {
-        LONG_SWAP(beg[i], beg[i-1]);
-        LONG_SWAP(end[i], end[i-1]);
-      }
-    }
-    else {
-      i--;
-    }
-  }
-}
-
 static void THTensor_(quicksortdescend)(real *arr, long *idx, long elements, long stride)
 {
   long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -931,20 +931,26 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
 {
   long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;
   real rswap, piv;
+
+#define LONG_SWAP(A, B) swap = A; A = B; B = swap
+#define REAL_SWAP(A, B) rswap = A; A = B; B = rswap
   
   beg[0]=0; end[0]=elements;
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
     if (L<R) {
       P=(L+R)>>1; /* Choose pivot as middle element of the current block */
+
       piv=arr[P*stride];
-      pid=idx[P*stride];
       rswap=arr[L*stride];
-      swap=idx[L*stride];
       arr[L*stride]=piv;
-      idx[L*stride]=pid;
       arr[P*stride]=rswap;
+
+      pid=idx[P*stride];
+      swap=idx[L*stride];
+      idx[L*stride]=pid;
       idx[P*stride]=swap;
+
       while (L<R) {
         while (arr[R*stride]>piv && L<R)
             R--;

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #ifndef TH_GENERIC_FILE
 #define TH_GENERIC_FILE "generic/THTensorMath.c"
 #else

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -946,9 +946,12 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
     if (L<R) {
-      P=(L+R)>>1; /* Choose pivot as middle element of the current block */
-
-      BOTH_SWAP(L, P);
+      /* Use median of three for pivot choice */
+      P=(L+R)>>1;
+      BOTH_SWAP((L+R)>>1, L+1);
+      if (ARR(L+1) > ARR(R)) { BOTH_SWAP(L+1, R); }
+      if (ARR(L) > ARR(R)) { BOTH_SWAP(L, R); }
+      if (ARR(L+1) > ARR(L)) { BOTH_SWAP(L+1, L); }
 
       piv=ARR(L);
       pid=IDX(L);

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -942,14 +942,10 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
       P=(L+R)>>1; /* Choose pivot as middle element of the current block */
 
       piv=arr[P*stride];
-      rswap=arr[L*stride];
-      arr[L*stride]=piv;
-      arr[P*stride]=rswap;
+      REAL_SWAP(arr[L*stride], arr[P*stride]);
 
       pid=idx[P*stride];
-      swap=idx[L*stride];
-      idx[L*stride]=pid;
-      idx[P*stride]=swap;
+      LONG_SWAP(idx[L*stride], idx[P*stride]);
 
       while (L<R) {
         while (arr[R*stride]>piv && L<R)
@@ -973,8 +969,8 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
       end[i+1]=end[i];
       end[i++]=L;
       if (end[i]-beg[i]>end[i-1]-beg[i-1]) {
-        swap=beg[i]; beg[i]=beg[i-1]; beg[i-1]=swap;
-        swap=end[i]; end[i]=end[i-1]; end[i-1]=swap;
+        LONG_SWAP(beg[i], beg[i-1]);
+        LONG_SWAP(end[i], end[i-1]);
       }
     }
     else {

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -934,7 +934,9 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
 
 #define LONG_SWAP(A, B) swap = A; A = B; B = swap
 #define REAL_SWAP(A, B) rswap = A; A = B; B = rswap
-  
+#define BOTH_SWAP(I, J) \
+  REAL_SWAP(arr[I*stride], arr[J*stride]); \
+  LONG_SWAP(idx[I*stride], idx[J*stride])
   beg[0]=0; end[0]=elements;
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
@@ -942,10 +944,9 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
       P=(L+R)>>1; /* Choose pivot as middle element of the current block */
 
       piv=arr[P*stride];
-      REAL_SWAP(arr[L*stride], arr[P*stride]);
-
       pid=idx[P*stride];
-      LONG_SWAP(idx[L*stride], idx[P*stride]);
+
+      BOTH_SWAP(L, P);
 
       while (L<R) {
         while (arr[R*stride]>piv && L<R)

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -932,40 +932,45 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
   long beg[MAX_LEVELS], end[MAX_LEVELS], i=0, L, R, P, swap, pid;
   real rswap, piv;
 
+#define ARR(I) arr[(I)*stride]
+#define IDX(I) idx[(I)*stride]
+
 #define LONG_SWAP(A, B) swap = A; A = B; B = swap
 #define REAL_SWAP(A, B) rswap = A; A = B; B = rswap
+
 #define BOTH_SWAP(I, J) \
-  REAL_SWAP(arr[I*stride], arr[J*stride]); \
-  LONG_SWAP(idx[I*stride], idx[J*stride])
+  REAL_SWAP(ARR(I), ARR(J)); \
+  LONG_SWAP(IDX(I), IDX(J))
+
   beg[0]=0; end[0]=elements;
   while (i>=0) {
     L=beg[i]; R=end[i]-1;
     if (L<R) {
       P=(L+R)>>1; /* Choose pivot as middle element of the current block */
 
-      piv=arr[P*stride];
-      pid=idx[P*stride];
-
       BOTH_SWAP(L, P);
 
+      piv=ARR(L);
+      pid=IDX(L);
+
       while (L<R) {
-        while (arr[R*stride]>piv && L<R)
+        while (ARR(R)>piv && L<R)
             R--;
         if (L<R) {
-            idx[L*stride]=idx[R*stride];
-            arr[L*stride]=arr[R*stride];
+            IDX(L)=IDX(R);
+            ARR(L)=ARR(R);
             L++;
         }
-        while (arr[L*stride]<piv && L<R)
+        while (ARR(L)<piv && L<R)
             L++;
         if (L<R) {
-            idx[R*stride]=idx[L*stride];
-            arr[R*stride]=arr[L*stride];
+            IDX(R)=IDX(L);
+            ARR(R)=ARR(L);
             R--;
         }
       }
-      idx[L*stride]=pid;
-      arr[L*stride]=piv;
+      IDX(L)=pid;
+      ARR(L)=piv;
       beg[i+1]=L+1;
       end[i+1]=end[i];
       end[i++]=L;

--- a/lib/TH/generic/THTensorMath.c
+++ b/lib/TH/generic/THTensorMath.c
@@ -1035,6 +1035,12 @@ static void THTensor_(quicksortascend)(real *arr, long *idx, long elements, long
   }
 }
 
+#undef ARR
+#undef IDX
+#undef LONG_SWAP
+#undef REAL_SWAP
+#undef BOTH_SWAP
+
 /* I cut and pasted (slightly adapted) the quicksort code from
    http://www.alienryderflex.com/quicksort/
    This public-domain C implementation by Darel Rex Finley.

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -1,58 +1,84 @@
+-- gnuplot.figure(1)
 -- Test torch sort, show it suffers from the problems of quicksort
 -- i.e. complexity O(N^2) in worst-case of sorted list
 require 'gnuplot'
 
-function testSort(output, descending)
-    descending = descending or false
+function main()
     local pow10 = torch.linspace(1,5,10)
-    local bench_rnd = torch.zeros(pow10:numel())
-    local bench_srt = torch.zeros(pow10:numel())
-    local bench_cst = torch.zeros(pow10:numel())
+    local old_bench_rnd = torch.zeros(pow10:numel())
+    local old_bench_srt = torch.zeros(pow10:numel())
+    local old_bench_cst = torch.zeros(pow10:numel())
+    local new_bench_rnd = torch.zeros(pow10:numel())
+    local new_bench_srt = torch.zeros(pow10:numel())
+    local new_bench_cst = torch.zeros(pow10:numel())
+    local ratio_rnd = torch.zeros(pow10:numel())
+    local ratio_srt = torch.zeros(pow10:numel())
+    local ratio_cst = torch.zeros(pow10:numel())
     local nrep = 3
 
+    -- Ascending sort uses new sort
     local function time_sort(x)
+        collectgarbage()
         local start = os.clock()
-        torch.sort(x,descending)
+        torch.sort(x,false)
+        return (os.clock()-start)
+    end
+
+    -- Descending sort uses old sort
+    local function time_old_sort(x)
+        collectgarbage()
+        local start = os.clock()
+        torch.sort(x,true)
         return (os.clock()-start)
     end
 
     for j = 1,nrep do
         for i = 1,pow10:numel() do
 
-            local this_time
+            local new_time, old_time
             local n = 10^pow10[i]
 
             -- on random
-            this_time = time_sort(torch.rand(n))
-            print('RND j:', j, 'for 10^', pow10[i], ' time: ', this_time)
-            bench_rnd[i] = bench_rnd[i] + this_time/nrep
-            collectgarbage()
+            new_time = time_sort(torch.rand(n))
+            old_time = time_old_sort(torch.rand(n))
+            new_bench_rnd[i] = new_bench_rnd[i] + new_time/nrep
+            old_bench_rnd[i] = old_bench_rnd[i] + old_time/nrep
+            ratio_rnd[i] = ratio_rnd[i] + (old_bench_rnd[i]/new_bench_rnd[i])/nrep
 
             -- on sorted
-            this_time = time_sort(torch.linspace(0,1,n))
-            print('SRT j:', j, 'for 10^', pow10[i], ' time: ', this_time)
-            bench_srt[i] = bench_srt[i] + this_time/nrep
-            collectgarbage()
+            new_time = time_sort(torch.linspace(0,1,n))
+            old_time = time_old_sort(torch.linspace(0,1,n):add(-1):mul(-1)) -- old_time is called on descending sort, hence the reversed input
+            new_bench_srt[i] = new_bench_srt[i] + new_time/nrep
+            old_bench_srt[i] = old_bench_srt[i] + old_time/nrep
+            ratio_srt[i] = ratio_srt[i] + (old_bench_srt[i]/new_bench_srt[i])/nrep
 
             -- on constant
-            this_time = time_sort(torch.zeros(n))
-            print('CST j:', j, 'for 10^', pow10[i], ' time: ', this_time)
-            bench_cst[i] = bench_cst[i] + this_time/nrep
-            collectgarbage()
-
+            new_time = time_sort(torch.zeros(n))
+            old_time = time_old_sort(torch.zeros(n))
+            new_bench_cst[i] = new_bench_cst[i] + new_time/nrep
+            old_bench_cst[i] = old_bench_cst[i] + old_time/nrep
+            ratio_cst[i] = ratio_cst[i] + (old_bench_cst[i]/new_bench_cst[i])/nrep
         end
         io.flush()
     end
-    gnuplot.plot({'Random', pow10, bench_rnd},
-                 {'Sorted', pow10, bench_srt},
-                 {'Constant', pow10, bench_cst})
+    gnuplot.figure(1)
+    gnuplot.plot({'Random - new', pow10, new_bench_rnd},
+                 {'Sorted - new', pow10, new_bench_srt},
+                 {'Constant - new', pow10, new_bench_cst},
+                 {'Random - old', pow10, old_bench_rnd},
+                 {'Sorted - old', pow10, old_bench_srt},
+                 {'Constant - old', pow10, old_bench_cst})
     gnuplot.xlabel('Log10(N)')
     gnuplot.ylabel('Time (s)')
-    gnuplot.figprint(output)
-    print('RND:', bench_rnd)
-    print('SRT:', bench_srt)
-    print('CST:', bench_cst)
+    gnuplot.figprint('benchmarkTime.png')
+
+    gnuplot.figure(2)
+    gnuplot.plot({'Random', pow10, ratio_rnd},
+                 {'Sorted', pow10, ratio_srt},
+                 {'Constant', pow10, ratio_cst})
+    gnuplot.xlabel('Log10(N)')
+    gnuplot.ylabel('Speed-up Factor (s)')
+    gnuplot.figprint('benchmarkRatio.png')
 end
 
-testSort('timeSortAscending.png', false) -- Ascending
-testSort('timeSortDescending.png', true) -- Descending
+main()

--- a/pkg/torch/test/timeSort.lua
+++ b/pkg/torch/test/timeSort.lua
@@ -1,20 +1,28 @@
--- gnuplot.figure(1)
+-- gnuplot.figure(2)
 -- Test torch sort, show it suffers from the problems of quicksort
 -- i.e. complexity O(N^2) in worst-case of sorted list
 require 'gnuplot'
 
+local cmd = torch.CmdLine()
+cmd:option('-N', 10^7, 'Maximum array size')
+cmd:option('-p',  50, 'Number of points in logspace')
+cmd:option('-r', 20, 'Number of repetitions')
+
+local options = cmd:parse(arg or {})
 function main()
-    local pow10 = torch.linspace(1,5,10)
-    local old_bench_rnd = torch.zeros(pow10:numel())
-    local old_bench_srt = torch.zeros(pow10:numel())
-    local old_bench_cst = torch.zeros(pow10:numel())
-    local new_bench_rnd = torch.zeros(pow10:numel())
-    local new_bench_srt = torch.zeros(pow10:numel())
-    local new_bench_cst = torch.zeros(pow10:numel())
-    local ratio_rnd = torch.zeros(pow10:numel())
-    local ratio_srt = torch.zeros(pow10:numel())
-    local ratio_cst = torch.zeros(pow10:numel())
-    local nrep = 3
+    local pow10 = torch.linspace(1,math.log10(options.N), options.p)
+    local num_sizes = options.p
+    local num_reps = options.r
+
+    local old_rnd = torch.zeros(num_sizes, num_reps)
+    local old_srt = torch.zeros(num_sizes, num_reps)
+    local old_cst = torch.zeros(num_sizes, num_reps)
+    local new_rnd = torch.zeros(num_sizes, num_reps)
+    local new_srt = torch.zeros(num_sizes, num_reps)
+    local new_cst = torch.zeros(num_sizes, num_reps)
+    local ratio_rnd = torch.zeros(num_sizes, num_reps)
+    local ratio_srt = torch.zeros(num_sizes, num_reps)
+    local ratio_cst = torch.zeros(num_sizes, num_reps)
 
     -- Ascending sort uses new sort
     local function time_sort(x)
@@ -32,53 +40,108 @@ function main()
         return (os.clock()-start)
     end
 
-    for j = 1,nrep do
-        for i = 1,pow10:numel() do
-
-            local new_time, old_time
-            local n = 10^pow10[i]
-
+    local benches = {
+        function(i,j,n)
             -- on random
-            new_time = time_sort(torch.rand(n))
-            old_time = time_old_sort(torch.rand(n))
-            new_bench_rnd[i] = new_bench_rnd[i] + new_time/nrep
-            old_bench_rnd[i] = old_bench_rnd[i] + old_time/nrep
-            ratio_rnd[i] = ratio_rnd[i] + (old_bench_rnd[i]/new_bench_rnd[i])/nrep
+            local input = torch.rand(n)
+            new_rnd[i][j] = time_sort(input:clone())
+            old_rnd[i][j] = time_old_sort(input:clone())
+        end,
 
+        function(i,j,n)
             -- on sorted
-            new_time = time_sort(torch.linspace(0,1,n))
-            old_time = time_old_sort(torch.linspace(0,1,n):add(-1):mul(-1)) -- old_time is called on descending sort, hence the reversed input
-            new_bench_srt[i] = new_bench_srt[i] + new_time/nrep
-            old_bench_srt[i] = old_bench_srt[i] + old_time/nrep
-            ratio_srt[i] = ratio_srt[i] + (old_bench_srt[i]/new_bench_srt[i])/nrep
+            new_srt[i][j] = time_sort(torch.linspace(0,1,n))
+            old_srt[i][j] = time_old_sort(torch.linspace(0,1,n):add(-1):mul(-1)) -- old_time is called on descending sort, hence the reversed input
+        end,
 
+        function(i,j,n)
             -- on constant
-            new_time = time_sort(torch.zeros(n))
-            old_time = time_old_sort(torch.zeros(n))
-            new_bench_cst[i] = new_bench_cst[i] + new_time/nrep
-            old_bench_cst[i] = old_bench_cst[i] + old_time/nrep
-            ratio_cst[i] = ratio_cst[i] + (old_bench_cst[i]/new_bench_cst[i])/nrep
+            new_cst[i][j] = time_sort(torch.zeros(n))
+            old_cst[i][j] = time_old_sort(torch.zeros(n))
         end
-        io.flush()
+    }
+
+    local num_benches = #benches
+    local num_exps = num_sizes * num_benches * num_reps
+
+    -- Full randomization
+    local perm = torch.randperm(num_exps):long()
+    local perm_benches = torch.Tensor(num_exps)
+    local perm_reps = torch.Tensor(num_exps)
+    local perm_sizes = torch.Tensor(num_exps)
+
+    local l = 1
+    for i=1, num_sizes do
+        for j=1, num_reps do
+            for k=1, num_benches do
+                perm_benches[ perm[l] ] = k
+                perm_reps[ perm[l] ] = j
+                perm_sizes[ perm[l] ] = i
+                l = l+1
+            end
+        end
     end
+
+    local pc = 0
+    for j = 1, num_exps do
+        local n = 10^pow10[perm_sizes[j]]
+    --    print(string.format('rep %d / %d, bench %d, size %d, rep %d\n', j, num_exps, perm_benches[j], n, perm_reps[j]))
+        if math.floor(100*j/num_exps) > pc then
+            pc = math.floor(100*j/num_exps)
+            io.write('.')
+            if math.mod(pc, 10) == 0 then
+                io.write(' ' .. pc .. '%\n')
+             end
+            io.flush()
+        end
+        benches[perm_benches[j]](perm_sizes[j], perm_reps[j], n)
+    end
+
+    ratio_rnd = torch.cdiv(old_rnd:mean(2), new_rnd:mean(2))
+    ratio_srt = torch.cdiv(old_srt:mean(2), new_srt:mean(2))
+    ratio_cst = torch.cdiv(old_cst:mean(2), new_cst:mean(2))
+
+    local N = pow10:clone():apply(function(x) return 10^x end)
+
+    gnuplot.setterm('x11')
     gnuplot.figure(1)
-    gnuplot.plot({'Random - new', pow10, new_bench_rnd},
-                 {'Sorted - new', pow10, new_bench_srt},
-                 {'Constant - new', pow10, new_bench_cst},
-                 {'Random - old', pow10, old_bench_rnd},
-                 {'Sorted - old', pow10, old_bench_srt},
-                 {'Constant - old', pow10, old_bench_cst})
-    gnuplot.xlabel('Log10(N)')
+    gnuplot.raw('set log x; set mxtics 10')
+    gnuplot.raw('set grid mxtics mytics xtics ytics')
+    gnuplot.raw('set xrange [' .. N:min() .. ':' .. N:max() .. ']' )
+    gnuplot.plot({'Random - new', N, new_rnd:mean(2)},
+                 {'Sorted - new', N, new_srt:mean(2)},
+                 {'Constant - new', N, new_cst:mean(2)},
+                 {'Random - old', N, old_rnd:mean(2)},
+                 {'Sorted - old', N, old_srt:mean(2)},
+                 {'Constant - old', N, old_cst:mean(2)})
+    gnuplot.xlabel('N')
     gnuplot.ylabel('Time (s)')
     gnuplot.figprint('benchmarkTime.png')
 
     gnuplot.figure(2)
-    gnuplot.plot({'Random', pow10, ratio_rnd},
-                 {'Sorted', pow10, ratio_srt},
-                 {'Constant', pow10, ratio_cst})
-    gnuplot.xlabel('Log10(N)')
+    gnuplot.raw('set log x; set mxtics 10')
+    gnuplot.raw('set grid mxtics mytics xtics ytics')
+    gnuplot.raw('set xrange [' .. N:min() .. ':' .. N:max() .. ']' )
+    gnuplot.plot({'Random', N, ratio_rnd:mean(2)},
+                 {'Sorted', N, ratio_srt:mean(2)},
+                 {'Constant', N, ratio_cst:mean(2)})
+    gnuplot.xlabel('N')
     gnuplot.ylabel('Speed-up Factor (s)')
     gnuplot.figprint('benchmarkRatio.png')
+    
+    torch.save('benchmark.t7', {
+               new_rnd=new_rnd,
+               new_srt=new_srt,
+               new_cst=new_cst, 
+               old_rnd=old_rnd,
+               old_srt=old_srt,
+               old_cst=old_cst,
+               ratio_rnd=ratio_rnd,
+               ratio_srt=ratio_srt,
+               ratio_cst=ratio_cst,
+               pow10 = pow10,
+               num_reps = num_reps
+           })
 end
 
 main()


### PR DESCRIPTION
Hi guys

As discussed with Koray, this pull request replaces the wikipedia-based-then-improved handmade implementation by an implementation from a reference academic article by Sedgewick (who did his thesis with Knuth on quicksort):

Sedgewick's 1978 "Implementing Quicksort Programs"
http://www.csie.ntu.edu.tw/~b93076/p847-sedgewick.pdf                                                                                                                                         

It is the state of the art existing implementation of regular single-pivot quicksort. The macros are here to make as close a match as possible to the pseudocode of Program 2 p.851.

Here are the benchmarks against the existing implementation: 

![benchmarkratio](https://f.cloud.github.com/assets/660037/1533420/477e02b8-4c85-11e3-96a4-594b19263f16.png)
![benchmarktime](https://f.cloud.github.com/assets/660037/1533421/478df0a6-4c85-11e3-9477-d2afe206432d.png)

As you can see, although we loose a little on very small arrays (which are so fast to sort that it is not noticeable), we gain up to 50% on constant arrays, and 10% on random arrays. We can even see the difference when some caching stops being done for large array sizes.

The advantage, beyond this reasonable improvement, is also that we now have a proper reference, with details about each carefuly made implementation decision by Sedgewick. 

Note that I have only done the ascending sort, leaving the descending sort as it was for comparison purposes. If you decide to merge this branch, I will copy/paste the code and change the inequalities to get the descending sort.
Cheers.
