### PR TITLE
fixed PairwiseDistance type() function bug.  Overloaded type now returns self.

### DIFF
--- a/extra/nn/PairwiseDistance.lua
+++ b/extra/nn/PairwiseDistance.lua
@@ -99,5 +99,6 @@ function PairwiseDistance:type(type)
    -- Now convert the left over table elements
    self.gradInput[1] = self.gradInput[1]:type(type)
    self.gradInput[2] = self.gradInput[2]:type(type)
+   return self
 end
 


### PR DESCRIPTION
This is an embarrassing one...

As per the behavior of Module:type(), the PairwiseDistance:type() also needs to return self.

This was also mentioned in pull request #183 (the bug was found after merging).

Sorry guys!
